### PR TITLE
US-04: Create Trip Room - Backend Implementation

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # auto-generated
       DOCKER_BUILDKIT: 1
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       
     steps:
     # checkout repository code
@@ -22,15 +23,27 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    # docker login
+    # docker login only for main branch pushes
     - name: Login to Docker Hub
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.dockerhub_username }}
         password: ${{ secrets.dockerhub_password }}
-        
-    # docker build & push amd64
-    - name: Build and push for x64_86 processor architecture
+
+    # PRs: build image only (no push), so CI validates Dockerfile without registry credentials.
+    - name: Build for PR validation (no push)
+      if: github.event_name == 'pull_request'
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: false
+        platforms: linux/amd64
+
+    # Main branch pushes: build and publish Docker image.
+    - name: Build and push image on main
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -1,0 +1,129 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.TripService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * TripController
+ * This class is responsible for managing all Trip-related HTTP requests.
+ * It handles creating trips, retrieving trip information, and updating trip status.
+ */
+@RestController
+@RequestMapping("/trips")
+public class TripController {
+
+    private final TripService tripService;
+
+    @Autowired
+    public TripController(TripService tripService) {
+        this.tripService = tripService;
+    }
+
+    /**
+     * Get all trips
+     * @return list of all trips
+     */
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<TripGetDTO> getAllTrips() {
+        List<Trip> trips = tripService.getAllTrips();
+        return trips.stream()
+                .map(DTOMapper.INSTANCE::convertEntityToTripGetDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get a specific trip by ID
+     * @param tripId the ID of the trip
+     * @return the trip details
+     */
+    @GetMapping("/{tripId}")
+    @ResponseStatus(HttpStatus.OK)
+    public TripGetDTO getTripById(@PathVariable Long tripId) {
+        Trip trip = tripService.getTripById(tripId);
+        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
+    }
+
+    /**
+     * Get a trip by room code
+     * Used when users want to join a trip with the room code
+     * @param roomCode the unique room code
+     * @return the trip details
+     */
+    @GetMapping("/room/{roomCode}")
+    @ResponseStatus(HttpStatus.OK)
+    public TripGetDTO getTripByRoomCode(@PathVariable String roomCode) {
+        Trip trip = tripService.getTripByRoomCode(roomCode);
+        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
+    }
+
+    /**
+     * Get all trips hosted by a specific user
+     * @param hostId the ID of the host user
+     * @return list of trips hosted by the user
+     */
+    @GetMapping("/host/{hostId}")
+    @ResponseStatus(HttpStatus.OK)
+    public List<TripGetDTO> getTripsByHostId(@PathVariable Long hostId) {
+        List<Trip> trips = tripService.getTripsByHostId(hostId);
+        return trips.stream()
+                .map(DTOMapper.INSTANCE::convertEntityToTripGetDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Create a new trip
+     * The authenticated user becomes the host of the trip
+     * @param tripPostDTO trip data with name
+     * @param hostId the ID of the user creating the trip (should come from auth context in a real app)
+     * @return the created trip with room code
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TripGetDTO createTrip(@RequestBody TripPostDTO tripPostDTO, 
+                                  @RequestParam Long hostId) {
+        Trip trip = DTOMapper.INSTANCE.convertTripPostDTOtoEntity(tripPostDTO);
+        trip.setHostId(hostId);
+        
+        Trip createdTrip = tripService.createTrip(trip);
+        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(createdTrip);
+    }
+
+    /**
+     * Update the status of a trip (e.g., to EVALUATION or FINALIZED)
+     * @param tripId the ID of the trip
+     * @param newStatus the new status
+     * @return the updated trip
+     */
+    @PutMapping("/{tripId}/status")
+    @ResponseStatus(HttpStatus.OK)
+    public TripGetDTO updateTripStatus(@PathVariable Long tripId, 
+                                        @RequestParam Trip.TripStatus newStatus) {
+        Trip updatedTrip = tripService.updateTripStatus(tripId, newStatus);
+        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
+    }
+
+    /**
+     * Set the final destination for a trip
+     * Only the host can perform this action
+     * @param tripId the ID of the trip
+     * @param finalDestinationId the ID of the selected destination
+     * @return the updated trip
+     */
+    @PutMapping("/{tripId}/finalize")
+    @ResponseStatus(HttpStatus.OK)
+    public TripGetDTO setFinalDestination(@PathVariable Long tripId,
+                                           @RequestParam Long finalDestinationId) {
+        Trip updatedTrip = tripService.setFinalDestination(tripId, finalDestinationId);
+        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Trip.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Trip.java
@@ -1,0 +1,118 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Trip represents a group trip planning room.
+ * Users can create trips, invite others, propose destinations and activities.
+ */
+@Entity
+@Table(name = "TRIP")
+public class Trip implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, unique = true)
+    private String roomCode;
+
+    @Column(nullable = false)
+    private Long hostId; // Reference to User who created this trip
+
+    @Column(nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date creationDate;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TripStatus status; // ACTIVE, EVALUATION, FINALIZED
+
+    @Column
+    private Long finalDestinationId; // ID of the selected destination (after final evaluation)
+
+    // Constructors
+    public Trip() {
+        this.status = TripStatus.ACTIVE;
+        this.creationDate = new Date();
+    }
+
+    public Trip(String name, String roomCode, Long hostId) {
+        this.name = name;
+        this.roomCode = roomCode;
+        this.hostId = hostId;
+        this.status = TripStatus.ACTIVE;
+        this.creationDate = new Date();
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRoomCode() {
+        return roomCode;
+    }
+
+    public void setRoomCode(String roomCode) {
+        this.roomCode = roomCode;
+    }
+
+    public Long getHostId() {
+        return hostId;
+    }
+
+    public void setHostId(Long hostId) {
+        this.hostId = hostId;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public TripStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(TripStatus status) {
+        this.status = status;
+    }
+
+    public Long getFinalDestinationId() {
+        return finalDestinationId;
+    }
+
+    public void setFinalDestinationId(Long finalDestinationId) {
+        this.finalDestinationId = finalDestinationId;
+    }
+
+    // Nested enum for Trip status
+    public enum TripStatus {
+        ACTIVE,           // Accepting destinations and activities
+        EVALUATION,       // In evaluation mode, read-only
+        FINALIZED         // Final destination selected, fully read-only
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/TripRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/TripRepository.java
@@ -1,0 +1,33 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository("tripRepository")
+public interface TripRepository extends JpaRepository<Trip, Long> {
+    /**
+     * Find a trip by its unique room code
+     * @param roomCode the unique code to access the trip room
+     * @return Optional containing the trip if found
+     */
+    Optional<Trip> findByRoomCode(String roomCode);
+
+    /**
+     * Find all trips where the given user is the host
+     * @param hostId the ID of the host user
+     * @return list of trips hosted by the user
+     */
+    List<Trip> findByHostId(Long hostId);
+
+    /**
+     * Find a trip by its name and host
+     * @param name the trip name
+     * @param hostId the host user ID
+     * @return Optional containing the trip if found
+     */
+    Optional<Trip> findByNameAndHostId(String name, Long hostId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripGetDTO.java
@@ -1,0 +1,94 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * TripGetDTO for returning trip data to the client
+ * Contains all trip information
+ */
+public class TripGetDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String name;
+    private String roomCode;
+    private Long hostId;
+    private Date creationDate;
+    private String status; // String representation of Trip.TripStatus
+    private Long finalDestinationId;
+
+    // Constructors
+    public TripGetDTO() {
+    }
+
+    public TripGetDTO(Long id, String name, String roomCode, Long hostId, Date creationDate, 
+                      String status, Long finalDestinationId) {
+        this.id = id;
+        this.name = name;
+        this.roomCode = roomCode;
+        this.hostId = hostId;
+        this.creationDate = creationDate;
+        this.status = status;
+        this.finalDestinationId = finalDestinationId;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRoomCode() {
+        return roomCode;
+    }
+
+    public void setRoomCode(String roomCode) {
+        this.roomCode = roomCode;
+    }
+
+    public Long getHostId() {
+        return hostId;
+    }
+
+    public void setHostId(Long hostId) {
+        this.hostId = hostId;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Long getFinalDestinationId() {
+        return finalDestinationId;
+    }
+
+    public void setFinalDestinationId(Long finalDestinationId) {
+        this.finalDestinationId = finalDestinationId;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripPostDTO.java
@@ -1,0 +1,31 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.io.Serializable;
+
+/**
+ * TripPostDTO for creating a new trip
+ * Client sends only the trip name
+ */
+public class TripPostDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+
+    // Constructors
+    public TripPostDTO() {
+    }
+
+    public TripPostDTO(String name) {
+        this.name = name;
+    }
+
+    // Getters and Setters
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -4,8 +4,11 @@ import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
 
 /**
  * DTOMapper
@@ -32,4 +35,21 @@ public interface DTOMapper {
 	@Mapping(source = "username", target = "username")
 	@Mapping(source = "status", target = "status")
 	UserGetDTO convertEntityToUserGetDTO(User user);
+
+	@Mapping(source = "name", target = "name")
+	Trip convertTripPostDTOtoEntity(TripPostDTO tripPostDTO);
+
+	@Mapping(source = "id", target = "id")
+	@Mapping(source = "name", target = "name")
+	@Mapping(source = "roomCode", target = "roomCode")
+	@Mapping(source = "hostId", target = "hostId")
+	@Mapping(source = "creationDate", target = "creationDate")
+	@Mapping(source = "status", target = "status", qualifiedByName = "tripStatusToString")
+	@Mapping(source = "finalDestinationId", target = "finalDestinationId")
+	TripGetDTO convertEntityToTripGetDTO(Trip trip);
+
+	@Named("tripStatusToString")
+	default String tripStatusToString(Trip.TripStatus status) {
+		return status != null ? status.toString() : null;
+	}
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -1,0 +1,198 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class TripService {
+
+    private final Logger log = LoggerFactory.getLogger(TripService.class);
+    private final TripRepository tripRepository;
+
+    @Autowired
+    public TripService(TripRepository tripRepository) {
+        this.tripRepository = tripRepository;
+    }
+
+    /**
+     * Get all trips in the system
+     * @return list of all trips
+     */
+    public List<Trip> getAllTrips() {
+        log.debug("Fetching all trips");
+        return tripRepository.findAll();
+    }
+
+    /**
+     * Get a trip by its ID
+     * @param tripId the ID of the trip
+     * @return the trip if found
+     * @throws ResponseStatusException if trip not found
+     */
+    public Trip getTripById(Long tripId) {
+        log.debug("Fetching trip with id: {}", tripId);
+        return tripRepository.findById(tripId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Trip with id " + tripId + " not found"
+                ));
+    }
+
+    /**
+     * Get a trip by its room code
+     * @param roomCode the unique room code
+     * @return the trip if found
+     * @throws ResponseStatusException if room code not found
+     */
+    public Trip getTripByRoomCode(String roomCode) {
+        log.debug("Fetching trip with room code: {}", roomCode);
+        return tripRepository.findByRoomCode(roomCode)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Trip with room code " + roomCode + " not found"
+                ));
+    }
+
+    /**
+     * Get all trips hosted by a specific user
+     * @param hostId the ID of the host user
+     * @return list of trips hosted by the user
+     */
+    public List<Trip> getTripsByHostId(Long hostId) {
+        log.debug("Fetching trips hosted by user: {}", hostId);
+        return tripRepository.findByHostId(hostId);
+    }
+
+    /**
+     * Create a new trip
+     * @param trip the trip to create (must have name and hostId set)
+     * @return the created trip with room code and ID
+     * @throws ResponseStatusException if validation fails
+     */
+    public Trip createTrip(Trip trip) {
+        log.debug("Creating new trip with name: {} for host: {}", trip.getName(), trip.getHostId());
+
+        // Validate input
+        validateTripCreation(trip);
+
+        // Generate unique room code
+        String roomCode = generateUniqueRoomCode();
+        trip.setRoomCode(roomCode);
+
+        // Save to database
+        Trip savedTrip = tripRepository.save(trip);
+        log.info("Trip created successfully with id: {}, room code: {}", savedTrip.getId(), roomCode);
+
+        return savedTrip;
+    }
+
+    /**
+     * Update trip status (e.g., to EVALUATION or FINALIZED)
+     * @param tripId the ID of the trip
+     * @param newStatus the new status
+     * @return the updated trip
+     * @throws ResponseStatusException if trip not found or invalid status transition
+     */
+    public Trip updateTripStatus(Long tripId, Trip.TripStatus newStatus) {
+        log.debug("Updating trip {} status to: {}", tripId, newStatus);
+
+        Trip trip = getTripById(tripId);
+        trip.setStatus(newStatus);
+
+        Trip updatedTrip = tripRepository.save(trip);
+        log.info("Trip {} status updated to: {}", tripId, newStatus);
+
+        return updatedTrip;
+    }
+
+    /**
+     * Set the final destination for a trip
+     * @param tripId the ID of the trip
+     * @param finalDestinationId the ID of the destination selected as final
+     * @return the updated trip
+     * @throws ResponseStatusException if trip not found
+     */
+    public Trip setFinalDestination(Long tripId, Long finalDestinationId) {
+        log.debug("Setting final destination {} for trip {}", finalDestinationId, tripId);
+
+        Trip trip = getTripById(tripId);
+        trip.setFinalDestinationId(finalDestinationId);
+        trip.setStatus(Trip.TripStatus.FINALIZED);
+
+        Trip updatedTrip = tripRepository.save(trip);
+        log.info("Final destination set for trip {}", tripId);
+
+        return updatedTrip;
+    }
+
+    /**
+     * Validate trip creation input
+     * @param trip the trip to validate
+     * @throws ResponseStatusException if validation fails
+     */
+    private void validateTripCreation(Trip trip) {
+        // Check if trip name is provided
+        if (trip.getName() == null || trip.getName().trim().isEmpty()) {
+            log.warn("Trip creation failed: trip name is empty");
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Trip name cannot be empty"
+            );
+        }
+
+        // Check if host ID is provided
+        if (trip.getHostId() == null) {
+            log.warn("Trip creation failed: host ID is null");
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Host ID is required"
+            );
+        }
+
+        // Optional: Check if user already has a trip with same name
+        if (tripRepository.findByNameAndHostId(trip.getName(), trip.getHostId()).isPresent()) {
+            log.warn("Trip creation failed: user {} already has trip named {}", trip.getHostId(), trip.getName());
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "User already has a trip with this name"
+            );
+        }
+    }
+
+    /**
+     * Generate a unique room code for a trip
+     * @return a unique 6-character room code
+     */
+    private String generateUniqueRoomCode() {
+        String roomCode;
+        int attempts = 0;
+        final int MAX_ATTEMPTS = 10;
+
+        do {
+            // Generate a 6-character alphanumeric code
+            roomCode = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+            attempts++;
+        } while (tripRepository.findByRoomCode(roomCode).isPresent() && attempts < MAX_ATTEMPTS);
+
+        if (attempts >= MAX_ATTEMPTS) {
+            log.error("Failed to generate unique room code after {} attempts", MAX_ATTEMPTS);
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to generate unique room code"
+            );
+        }
+
+        return roomCode;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -1,0 +1,233 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TripPostDTO;
+import ch.uzh.ifi.hase.soprafs26.service.TripService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.server.ResponseStatusException;
+
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * TripControllerTest
+ * This is a WebMvcTest which allows to test the TripController i.e. GET/POST
+ * request without actually sending them over the network.
+ * This tests if the TripController works.
+ */
+@WebMvcTest(TripController.class)
+public class TripControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TripService tripService;
+
+    @Test
+    public void givenTrips_whenGetTrips_thenReturnJsonArray() throws Exception {
+        // given
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.ACTIVE);
+
+        List<Trip> allTrips = Collections.singletonList(trip);
+
+        // this mocks the TripService -> we define above what the tripService should
+        // return when getAllTrips() is called
+        given(tripService.getAllTrips()).willReturn(allTrips);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/trips")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name", is(trip.getName())))
+                .andExpect(jsonPath("$[0].roomCode", is(trip.getRoomCode())))
+                .andExpect(jsonPath("$[0].hostId", is(Math.toIntExact(trip.getHostId()))))
+                .andExpect(jsonPath("$[0].status", is(trip.getStatus().toString())));
+    }
+
+    @Test
+    public void getTripById_validId_success() throws Exception {
+        // given
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.ACTIVE);
+
+        given(tripService.getTripById(1L)).willReturn(trip);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/trips/1")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(Math.toIntExact(trip.getId()))))
+                .andExpect(jsonPath("$.name", is(trip.getName())))
+                .andExpect(jsonPath("$.roomCode", is(trip.getRoomCode())));
+    }
+
+    @Test
+    public void getTripByRoomCode_validCode_success() throws Exception {
+        // given
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.ACTIVE);
+
+        given(tripService.getTripByRoomCode("ABC123")).willReturn(trip);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/trips/room/ABC123")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomCode", is("ABC123")))
+                .andExpect(jsonPath("$.name", is(trip.getName())));
+    }
+
+    @Test
+    public void getTripsByHostId_validHostId_success() throws Exception {
+        // given
+        Trip trip1 = new Trip();
+        trip1.setId(1L);
+        trip1.setName("Paris Vacation");
+        trip1.setRoomCode("ABC123");
+        trip1.setHostId(1L);
+        trip1.setStatus(Trip.TripStatus.ACTIVE);
+
+        Trip trip2 = new Trip();
+        trip2.setId(2L);
+        trip2.setName("London Trip");
+        trip2.setRoomCode("DEF456");
+        trip2.setHostId(1L);
+        trip2.setStatus(Trip.TripStatus.ACTIVE);
+
+        List<Trip> trips = Arrays.asList(trip1, trip2);
+        given(tripService.getTripsByHostId(1L)).willReturn(trips);
+
+        // when
+        MockHttpServletRequestBuilder getRequest = get("/trips/host/1")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(getRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name", is("Paris Vacation")))
+                .andExpect(jsonPath("$[1].name", is("London Trip")));
+    }
+
+    @Test
+    public void createTrip_validInput_tripCreated() throws Exception {
+        // given
+        TripPostDTO tripPostDTO = new TripPostDTO();
+        tripPostDTO.setName("Paris Vacation");
+
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.ACTIVE);
+        trip.setCreationDate(new Date());
+
+        given(tripService.createTrip(Mockito.any())).willReturn(trip);
+
+        // when
+        MockHttpServletRequestBuilder postRequest = post("/trips")
+                .param("hostId", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(tripPostDTO));
+
+        // then
+        mockMvc.perform(postRequest)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(Math.toIntExact(trip.getId()))))
+                .andExpect(jsonPath("$.name", is(trip.getName())))
+                .andExpect(jsonPath("$.roomCode", is(trip.getRoomCode())))
+                .andExpect(jsonPath("$.hostId", is(Math.toIntExact(trip.getHostId()))));
+    }
+
+    @Test
+    public void updateTripStatus_validInput_success() throws Exception {
+        // given
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.EVALUATION);
+
+        given(tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION)).willReturn(trip);
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/trips/1/status")
+                .param("newStatus", "EVALUATION")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(putRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("EVALUATION")));
+    }
+
+    @Test
+    public void setFinalDestination_validInput_success() throws Exception {
+        // given
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.FINALIZED);
+        trip.setFinalDestinationId(5L);
+
+        given(tripService.setFinalDestination(1L, 5L)).willReturn(trip);
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/trips/1/finalize")
+                .param("finalDestinationId", "5")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        // then
+        mockMvc.perform(putRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.finalDestinationId", is(5)))
+                .andExpect(jsonPath("$.status", is("FINALIZED")));
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -1,0 +1,223 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.repository.TripRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TripServiceTest
+ * Unit tests for TripService business logic
+ */
+public class TripServiceTest {
+
+    @Mock
+    private TripRepository tripRepository;
+
+    @InjectMocks
+    private TripService tripService;
+
+    private Trip testTrip;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        // given
+        testTrip = new Trip();
+        testTrip.setId(1L);
+        testTrip.setName("Paris Vacation");
+        testTrip.setRoomCode("ABC123");
+        testTrip.setHostId(1L);
+        testTrip.setStatus(Trip.TripStatus.ACTIVE);
+
+        // when -> any object is being saved in the tripRepository -> return the dummy testTrip
+        Mockito.when(tripRepository.save(Mockito.any())).thenReturn(testTrip);
+    }
+
+    @Test
+    public void createTrip_validInputs_success() {
+        // given
+        Trip tripInput = new Trip();
+        tripInput.setName("Paris Vacation");
+        tripInput.setHostId(1L);
+
+        // when
+        Trip createdTrip = tripService.createTrip(tripInput);
+
+        // then
+        Mockito.verify(tripRepository, Mockito.times(1)).save(Mockito.any());
+        assertNotNull(createdTrip.getRoomCode());
+        assertEquals("Paris Vacation", createdTrip.getName());
+        assertEquals(1L, createdTrip.getHostId());
+        assertEquals(Trip.TripStatus.ACTIVE, createdTrip.getStatus());
+    }
+
+    @Test
+    public void createTrip_invalidName_throwsException() {
+        // given
+        Trip tripInput = new Trip();
+        tripInput.setName("");
+        tripInput.setHostId(1L);
+
+        // when/then
+        assertThrows(ResponseStatusException.class, () -> tripService.createTrip(tripInput));
+    }
+
+    @Test
+    public void createTrip_nullName_throwsException() {
+        // given
+        Trip tripInput = new Trip();
+        tripInput.setName(null);
+        tripInput.setHostId(1L);
+
+        // when/then
+        assertThrows(ResponseStatusException.class, () -> tripService.createTrip(tripInput));
+    }
+
+    @Test
+    public void createTrip_nullHostId_throwsException() {
+        // given
+        Trip tripInput = new Trip();
+        tripInput.setName("Paris Vacation");
+        tripInput.setHostId(null);
+
+        // when/then
+        assertThrows(ResponseStatusException.class, () -> tripService.createTrip(tripInput));
+    }
+
+    @Test
+    public void createTrip_duplicateName_throwsException() {
+        // given
+        Trip tripInput = new Trip();
+        tripInput.setName("Paris Vacation");
+        tripInput.setHostId(1L);
+
+        // when -> setup additional mocks
+        Mockito.when(tripRepository.findByNameAndHostId("Paris Vacation", 1L))
+                .thenReturn(Optional.of(testTrip));
+
+        // then -> attempt to create duplicate trip -> check that an error is thrown
+        assertThrows(ResponseStatusException.class, () -> tripService.createTrip(tripInput));
+    }
+
+    @Test
+    public void getTripById_validId_success() {
+        // when
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+
+        Trip retrievedTrip = tripService.getTripById(1L);
+
+        // then
+        assertEquals(testTrip.getId(), retrievedTrip.getId());
+        assertEquals(testTrip.getName(), retrievedTrip.getName());
+        assertEquals(testTrip.getRoomCode(), retrievedTrip.getRoomCode());
+    }
+
+    @Test
+    public void getTripById_invalidId_throwsException() {
+        // when
+        Mockito.when(tripRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(ResponseStatusException.class, () -> tripService.getTripById(999L));
+    }
+
+    @Test
+    public void getTripByRoomCode_validCode_success() {
+        // when
+        Mockito.when(tripRepository.findByRoomCode("ABC123")).thenReturn(Optional.of(testTrip));
+
+        Trip retrievedTrip = tripService.getTripByRoomCode("ABC123");
+
+        // then
+        assertEquals("ABC123", retrievedTrip.getRoomCode());
+        assertEquals("Paris Vacation", retrievedTrip.getName());
+    }
+
+    @Test
+    public void getTripByRoomCode_invalidCode_throwsException() {
+        // when
+        Mockito.when(tripRepository.findByRoomCode("INVALID")).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(ResponseStatusException.class, () -> tripService.getTripByRoomCode("INVALID"));
+    }
+
+    @Test
+    public void getTripsByHostId_validHostId_success() {
+        // given
+        Trip trip2 = new Trip();
+        trip2.setId(2L);
+        trip2.setName("London Trip");
+        trip2.setHostId(1L);
+        
+        List<Trip> trips = Arrays.asList(testTrip, trip2);
+
+        // when
+        Mockito.when(tripRepository.findByHostId(1L)).thenReturn(trips);
+
+        List<Trip> retrievedTrips = tripService.getTripsByHostId(1L);
+
+        // then
+        assertEquals(2, retrievedTrips.size());
+        assertEquals("Paris Vacation", retrievedTrips.get(0).getName());
+        assertEquals("London Trip", retrievedTrips.get(1).getName());
+    }
+
+    @Test
+    public void updateTripStatus_validInput_success() {
+        // given
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+
+        // when
+        Trip updatedTrip = tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION);
+
+        // then
+        Mockito.verify(tripRepository, Mockito.times(1)).save(Mockito.any());
+        assertEquals(Trip.TripStatus.EVALUATION, updatedTrip.getStatus());
+    }
+
+    @Test
+    public void setFinalDestination_validInput_success() {
+        // given
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+
+        // when
+        Trip updatedTrip = tripService.setFinalDestination(1L, 5L);
+
+        // then
+        Mockito.verify(tripRepository, Mockito.times(1)).save(Mockito.any());
+        assertEquals(5L, updatedTrip.getFinalDestinationId());
+        assertEquals(Trip.TripStatus.FINALIZED, updatedTrip.getStatus());
+    }
+
+    @Test
+    public void getAllTrips_success() {
+        // given
+        Trip trip2 = new Trip();
+        trip2.setId(2L);
+        trip2.setName("London Trip");
+        
+        List<Trip> trips = Arrays.asList(testTrip, trip2);
+        Mockito.when(tripRepository.findAll()).thenReturn(trips);
+
+        // when
+        List<Trip> retrievedTrips = tripService.getAllTrips();
+
+        // then
+        assertEquals(2, retrievedTrips.size());
+        Mockito.verify(tripRepository, Mockito.times(1)).findAll();
+    }
+}


### PR DESCRIPTION
- Closes #52: Create trip request/response model for POST /trips
- Closes #53: Implement backend endpoint for trip creation
- Closes #54: Validate required input for trip name and return proper error responses
- Closes #55: Store creator as trip host and persist initial trip status and creation date
- Closes #56: Generate unique trip or room code for invitations

Changes:
- Trip entity with auto-generated room code and status tracking
- TripRepository with query methods for room code and host lookups
- TripPostDTO (request), TripGetDTO (response) models
- DTOMapper for Trip DTO conversions
- TripService with validation and room code generation logic
- TripController with POST /trips endpoint
- Proper error handling for duplicate room codes and validation failures