### PR TITLE
Feature/us14 be trip finalization

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -176,7 +176,16 @@ public class TripController {
     public TripGetDTO updateTripStatus(@RequestHeader(value = "Authorization", required = false) String token,
                                        @PathVariable Long tripId,
                                        @RequestParam Trip.TripStatus newStatus) {
-        userService.validateToken(token);
+        User authenticatedUser = userService.validateToken(token);
+
+        Trip trip = tripService.getTripById(tripId);
+        if (!trip.getHostId().equals(authenticatedUser.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Only the host can update this trip's status"
+            );
+        }
+
         Trip updatedTrip = tripService.updateTripStatus(tripId, newStatus);
         return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementService.java
@@ -15,11 +15,14 @@ public class ActivityManagementService {
 
     private final ActivityRepository activityRepository;
     private final DestinationService destinationService;
+    private final TripService tripService;
 
     public ActivityManagementService(ActivityRepository activityRepository,
-                                     DestinationService destinationService) {
+                                     DestinationService destinationService,
+                                     TripService tripService) {
         this.activityRepository = activityRepository;
         this.destinationService = destinationService;
+        this.tripService = tripService;
     }
 
     public List<Activity> getSelectedActivities(Long tripId, Long destinationId) {
@@ -30,6 +33,7 @@ public class ActivityManagementService {
     }
 
     public Activity addActivity(Long tripId, Long destinationId, Activity activityInput) {
+        tripService.ensureTripIsActiveForMutations(tripId);
         destinationService.getDestinationEntity(tripId, destinationId);
         validateActivity(activityInput);
 
@@ -52,6 +56,7 @@ public class ActivityManagementService {
     }
 
     public Activity updateActivity(Long tripId, Long destinationId, Long activityId, Activity activityUpdate) {
+        tripService.ensureTripIsActiveForMutations(tripId);
         destinationService.getDestinationEntity(tripId, destinationId);
         validateActivity(activityUpdate);
 
@@ -70,6 +75,7 @@ public class ActivityManagementService {
     }
 
     public void deleteActivity(Long tripId, Long destinationId, Long activityId) {
+        tripService.ensureTripIsActiveForMutations(tripId);
         destinationService.getDestinationEntity(tripId, destinationId);
 
         Activity activity = activityRepository.findByIdAndTripIdAndDestinationId(activityId, tripId, destinationId)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/DestinationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/DestinationService.java
@@ -27,7 +27,7 @@ public class DestinationService {
     }
 
     public Destination createDestination(Long tripId, Destination destination) {
-        tripService.getTripById(tripId);
+        tripService.ensureTripIsActiveForMutations(tripId);
         destination.setTripId(tripId);
         validate(destination);
 
@@ -35,6 +35,7 @@ public class DestinationService {
     }
 
     public Destination updateDestination(Long tripId, Long destinationId, Destination destinationUpdate) {
+        tripService.ensureTripIsActiveForMutations(tripId);
         validate(destinationUpdate);
         Destination destination = getDestinationEntity(tripId, destinationId);
         destination.setDestinationName(destinationUpdate.getDestinationName().trim());
@@ -42,6 +43,7 @@ public class DestinationService {
     }
 
     public void deleteDestination(Long tripId, Long destinationId) {
+        tripService.ensureTripIsActiveForMutations(tripId);
         Destination destination = getDestinationEntity(tripId, destinationId);
         destinationRepository.delete(destination);
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -133,10 +133,7 @@ public class TripService {
         Trip trip = getTripById(tripId);
         validateDestinationInput(destination);
         ensureParticipant(tripId, userId);
-
-        if (trip.getStatus() != Trip.TripStatus.ACTIVE) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Destinations can only be added while trip is ACTIVE");
-        }
+        ensureTripIsActiveForMutations(trip);
 
         destination.setTripId(tripId);
         destination.setProposedByUserId(userId);
@@ -167,12 +164,35 @@ public class TripService {
         log.debug("Updating trip {} status to: {}", tripId, newStatus);
 
         Trip trip = getTripById(tripId);
+        validateEvaluationTransition(trip, newStatus);
         trip.setStatus(newStatus);
 
         Trip updatedTrip = tripRepository.save(trip);
         log.info("Trip {} status updated to: {}", tripId, newStatus);
 
         return updatedTrip;
+    }
+
+    /**
+     * Shared guard for write operations that are only allowed while the trip is ACTIVE.
+     * Can be reused by other services handling destination/activity/comment/vote mutations.
+     * @param trip trip entity
+     */
+    public void ensureTripIsActiveForMutations(Trip trip) {
+        if (trip.getStatus() != Trip.TripStatus.ACTIVE) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Trip is in read-only mode. Mutations are only allowed while trip is ACTIVE"
+            );
+        }
+    }
+
+    /**
+     * Convenience overload to enforce ACTIVE mode by trip id.
+     * @param tripId target trip id
+     */
+    public void ensureTripIsActiveForMutations(Long tripId) {
+        ensureTripIsActiveForMutations(getTripById(tripId));
     }
 
     /**
@@ -266,5 +286,32 @@ public class TripService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Destination name cannot be empty");
         }
         destination.setDestinationName(destination.getDestinationName().trim());
+    }
+
+    /**
+     * Validates whether the requested status transition is allowed for entering evaluation mode.
+     */
+    private void validateEvaluationTransition(Trip trip, Trip.TripStatus newStatus) {
+        if (newStatus != Trip.TripStatus.EVALUATION) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Only transition to EVALUATION is supported via this endpoint"
+            );
+        }
+
+        if (trip.getStatus() == Trip.TripStatus.EVALUATION) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Trip is already in EVALUATION mode");
+        }
+
+        if (trip.getStatus() == Trip.TripStatus.FINALIZED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Trip is FINALIZED and cannot enter EVALUATION");
+        }
+
+        if (destinationRepository.findByTripIdOrderByIdDesc(trip.getId()).isEmpty()) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "At least one destination is required before entering EVALUATION"
+            );
+        }
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -225,6 +225,7 @@ public class TripControllerTest {
         trip.setStatus(Trip.TripStatus.EVALUATION);
 
         given(userService.validateToken("Bearer 1")).willReturn(authenticatedUser());
+        given(tripService.getTripById(1L)).willReturn(trip);
         given(tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION)).willReturn(trip);
 
         // when
@@ -237,6 +238,34 @@ public class TripControllerTest {
         mockMvc.perform(putRequest)
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status", is("EVALUATION")));
+    }
+
+    @Test
+    public void updateTripStatus_nonHost_forbidden() throws Exception {
+        // given
+        User nonHost = new User();
+        nonHost.setId(2L);
+        nonHost.setUsername("nonHostUser");
+
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.ACTIVE);
+
+        given(userService.validateToken("Bearer valid-token")).willReturn(nonHost);
+        given(tripService.getTripById(1L)).willReturn(trip);
+
+        // when
+        MockHttpServletRequestBuilder putRequest = put("/trips/1/status")
+                .param("newStatus", "EVALUATION")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer valid-token");
+
+        // then
+        mockMvc.perform(putRequest)
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
@@ -24,6 +25,9 @@ public class ActivityManagementServiceTest {
 
     @Mock
     private DestinationService destinationService;
+
+    @Mock
+    private TripService tripService;
 
     @InjectMocks
     private ActivityManagementService activityManagementService;
@@ -150,5 +154,40 @@ public class ActivityManagementServiceTest {
         activityManagementService.deleteActivity(1L, 2L, 10L);
 
         Mockito.verify(activityRepository, Mockito.times(1)).delete(existing);
+    }
+
+    @Test
+    public void addActivity_readOnlyMode_badRequest() {
+        Activity input = new Activity();
+        input.setPlaceId("place-1");
+        input.setName("City Museum");
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
+                .when(tripService).ensureTripIsActiveForMutations(1L);
+
+        assertThrows(ResponseStatusException.class, () -> activityManagementService.addActivity(1L, 2L, input));
+        Mockito.verifyNoInteractions(destinationService, activityRepository);
+    }
+
+    @Test
+    public void updateActivity_readOnlyMode_badRequest() {
+        Activity input = new Activity();
+        input.setPlaceId("place-1");
+        input.setName("City Museum Updated");
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
+                .when(tripService).ensureTripIsActiveForMutations(1L);
+
+        assertThrows(ResponseStatusException.class, () -> activityManagementService.updateActivity(1L, 2L, 10L, input));
+        Mockito.verifyNoInteractions(destinationService, activityRepository);
+    }
+
+    @Test
+    public void deleteActivity_readOnlyMode_badRequest() {
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
+                .when(tripService).ensureTripIsActiveForMutations(1L);
+
+        assertThrows(ResponseStatusException.class, () -> activityManagementService.deleteActivity(1L, 2L, 10L));
+        Mockito.verifyNoInteractions(destinationService, activityRepository);
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceTest.java
@@ -1,0 +1,84 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Destination;
+import ch.uzh.ifi.hase.soprafs26.repository.DestinationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DestinationServiceTest {
+
+    @Mock
+    private DestinationRepository destinationRepository;
+
+    @Mock
+    private TripService tripService;
+
+    @InjectMocks
+    private DestinationService destinationService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void createDestination_readOnlyMode_badRequest() {
+        Destination destination = new Destination();
+        destination.setDestinationName("Zurich");
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
+                .when(tripService).ensureTripIsActiveForMutations(1L);
+
+        assertThrows(ResponseStatusException.class, () -> destinationService.createDestination(1L, destination));
+        Mockito.verifyNoInteractions(destinationRepository);
+    }
+
+    @Test
+    public void updateDestination_readOnlyMode_badRequest() {
+        Destination update = new Destination();
+        update.setDestinationName("Basel");
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
+                .when(tripService).ensureTripIsActiveForMutations(1L);
+
+        assertThrows(ResponseStatusException.class, () -> destinationService.updateDestination(1L, 11L, update));
+        Mockito.verifyNoInteractions(destinationRepository);
+    }
+
+    @Test
+    public void deleteDestination_readOnlyMode_badRequest() {
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
+                .when(tripService).ensureTripIsActiveForMutations(1L);
+
+        assertThrows(ResponseStatusException.class, () -> destinationService.deleteDestination(1L, 11L));
+        Mockito.verifyNoInteractions(destinationRepository);
+    }
+
+    @Test
+    public void updateDestination_activeMode_success() {
+        Destination existing = new Destination();
+        existing.setId(11L);
+        existing.setTripId(1L);
+        existing.setDestinationName("Old Name");
+
+        Destination update = new Destination();
+        update.setDestinationName("New Name");
+
+        Mockito.when(destinationRepository.findByIdAndTripId(11L, 1L)).thenReturn(Optional.of(existing));
+        Mockito.when(destinationRepository.save(Mockito.any(Destination.class))).thenReturn(existing);
+
+        destinationService.updateDestination(1L, 11L, update);
+
+        Mockito.verify(destinationRepository, Mockito.times(1)).save(existing);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -193,6 +193,11 @@ public class TripServiceTest {
     public void updateTripStatus_validInput_success() {
         // given
         Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+        Destination existingDestination = new Destination();
+        existingDestination.setId(10L);
+        existingDestination.setTripId(1L);
+        existingDestination.setDestinationName("Zurich");
+        Mockito.when(destinationRepository.findByTripIdOrderByIdDesc(1L)).thenReturn(List.of(existingDestination));
 
         // when
         Trip updatedTrip = tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION);
@@ -200,6 +205,45 @@ public class TripServiceTest {
         // then
         Mockito.verify(tripRepository, Mockito.times(1)).save(Mockito.any());
         assertEquals(Trip.TripStatus.EVALUATION, updatedTrip.getStatus());
+    }
+
+    @Test
+    public void updateTripStatus_noDestinations_badRequest() {
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+        Mockito.when(destinationRepository.findByTripIdOrderByIdDesc(1L)).thenReturn(List.of());
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    public void updateTripStatus_alreadyEvaluation_conflict() {
+        testTrip.setStatus(Trip.TripStatus.EVALUATION);
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION)
+        );
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+    }
+
+    @Test
+    public void updateTripStatus_finalized_conflict() {
+        testTrip.setStatus(Trip.TripStatus.FINALIZED);
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION)
+        );
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
As a logged-in user host, I want to click on the “Final Evaluation” button in order to stop accepting new submissions and change to evaluation mode which is read only.

 The “Final Evaluation” button is visible only to the host.
 
The button is only enabled if:
At least one destination exists.
The room is not already in evaluation mode.
The room is not finalized.

In evaluation mode:
No new destinations can be added.
No destinations can be edited or deleted.
No new activities can be added.
No activities can be edited or deleted.
No new comments can be added. No votes can be cast or changed.
All interaction buttons related to creation, editing, deleting, or voting are disabled.

Implemented in 88b2926b770b45bf10af2ce5e05fcd50f5e8eb84