### PR TITLE
Final Evaluation Mode backend implementation adjusted (US-14) 

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -60,7 +60,7 @@ public class TripController {
         User authenticatedUser = userService.validateToken(token);
         List<Trip> trips = tripService.getTripsForUser(authenticatedUser.getId());
         return trips.stream()
-                .map(DTOMapper.INSTANCE::convertEntityToTripGetDTO)
+                .map(trip -> toTripGetDTOForUser(trip, authenticatedUser.getId()))
                 .collect(Collectors.toList());
     }
 
@@ -72,9 +72,9 @@ public class TripController {
     @GetMapping("/{tripId}")
     @ResponseStatus(HttpStatus.OK)
     public TripGetDTO getTripById(@RequestHeader(value = "Authorization", required = false) String token,@PathVariable Long tripId) {
-        userService.validateToken(token);
+        User authenticatedUser = userService.validateToken(token);
         Trip trip = tripService.getTripById(tripId);
-        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
+        return toTripGetDTOForUser(trip, authenticatedUser.getId());
     }
 
     /**
@@ -87,9 +87,9 @@ public class TripController {
     @ResponseStatus(HttpStatus.OK)
     public TripGetDTO getTripByRoomCode(@RequestHeader(value = "Authorization", required = false) String token,
                                         @PathVariable String roomCode) {
-        userService.validateToken(token);
+        User authenticatedUser = userService.validateToken(token);
         Trip trip = tripService.getTripByRoomCode(roomCode);
-        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
+        return toTripGetDTOForUser(trip, authenticatedUser.getId());
     }
 
     /**
@@ -124,10 +124,10 @@ public class TripController {
     @ResponseStatus(HttpStatus.OK)
     public List<TripGetDTO> getTripsByHostId(@RequestHeader(value = "Authorization", required = false) String token,
                                              @PathVariable Long hostId) {
-        userService.validateToken(token);
+        User authenticatedUser = userService.validateToken(token);
         List<Trip> trips = tripService.getTripsByHostId(hostId);
         return trips.stream()
-                .map(DTOMapper.INSTANCE::convertEntityToTripGetDTO)
+            .map(trip -> toTripGetDTOForUser(trip, authenticatedUser.getId()))
                 .collect(Collectors.toList());
     }
 
@@ -147,7 +147,7 @@ public class TripController {
         trip.setHostId(authenticatedUser.getId());
         
         Trip createdTrip = tripService.createTrip(trip);
-        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(createdTrip);
+        return toTripGetDTOForUser(createdTrip, authenticatedUser.getId());
     }
 
     /**
@@ -203,7 +203,7 @@ public class TripController {
         }
 
         Trip updatedTrip = tripService.enterFinalEvaluation(tripId, authenticatedUser.getId());
-        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
+        return toTripGetDTOForUser(updatedTrip, authenticatedUser.getId());
     }
 
     /**
@@ -219,7 +219,7 @@ public class TripController {
                                            @PathVariable Long tripId) {
         User authenticatedUser = userService.validateToken(token);
         Trip updatedTrip = tripService.enterFinalEvaluation(tripId, authenticatedUser.getId());
-        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
+        return toTripGetDTOForUser(updatedTrip, authenticatedUser.getId());
     }
 
     /**
@@ -234,8 +234,18 @@ public class TripController {
     public TripGetDTO setFinalDestination(@RequestHeader(value = "Authorization", required = false) String token,
                                            @PathVariable Long tripId,
                                            @RequestParam Long finalDestinationId) {
-        userService.validateToken(token);
+        User authenticatedUser = userService.validateToken(token);
         Trip updatedTrip = tripService.setFinalDestination(tripId, finalDestinationId);
-        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
+        return toTripGetDTOForUser(updatedTrip, authenticatedUser.getId());
+    }
+
+    private TripGetDTO toTripGetDTOForUser(Trip trip, Long userId) {
+        TripGetDTO dto = DTOMapper.INSTANCE.convertEntityToTripGetDTO(trip);
+        boolean isHost = trip.getHostId() != null && trip.getHostId().equals(userId);
+        dto.setHost(isHost);
+        dto.setEvaluationMode(trip.getStatus() == Trip.TripStatus.EVALUATION);
+        dto.setFinalized(trip.getStatus() == Trip.TripStatus.FINALIZED);
+        dto.setCanEnterFinalEvaluation(tripService.canEnterFinalEvaluation(trip, userId));
+        return dto;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/TripController.java
@@ -195,15 +195,30 @@ public class TripController {
                                        @RequestParam Trip.TripStatus newStatus) {
         User authenticatedUser = userService.validateToken(token);
 
-        Trip trip = tripService.getTripById(tripId);
-        if (!trip.getHostId().equals(authenticatedUser.getId())) {
+        if (newStatus != Trip.TripStatus.EVALUATION) {
             throw new ResponseStatusException(
-                    HttpStatus.FORBIDDEN,
-                    "Only the host can update this trip's status"
+                    HttpStatus.BAD_REQUEST,
+                    "Only transition to EVALUATION is supported via this endpoint"
             );
         }
 
-        Trip updatedTrip = tripService.updateTripStatus(tripId, newStatus);
+        Trip updatedTrip = tripService.enterFinalEvaluation(tripId, authenticatedUser.getId());
+        return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
+    }
+
+    /**
+     * Enter final evaluation mode.
+     * Dedicated endpoint for host action "Final Evaluation".
+     * @param tripId the ID of the trip
+     * @param token Authorization header containing Bearer token
+     * @return the updated trip in EVALUATION status
+     */
+    @PostMapping("/{tripId}/final-evaluation")
+    @ResponseStatus(HttpStatus.OK)
+    public TripGetDTO enterFinalEvaluation(@RequestHeader(value = "Authorization", required = false) String token,
+                                           @PathVariable Long tripId) {
+        User authenticatedUser = userService.validateToken(token);
+        Trip updatedTrip = tripService.enterFinalEvaluation(tripId, authenticatedUser.getId());
         return DTOMapper.INSTANCE.convertEntityToTripGetDTO(updatedTrip);
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/DestinationRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/DestinationRepository.java
@@ -11,5 +11,7 @@ import java.util.Optional;
 public interface DestinationRepository extends JpaRepository<Destination, Long> {
     List<Destination> findByTripIdOrderByIdDesc(Long tripId);
 
+    boolean existsByTripId(Long tripId);
+
     Optional<Destination> findByIdAndTripId(Long destinationId, Long tripId);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/TripGetDTO.java
@@ -17,13 +17,18 @@ public class TripGetDTO implements Serializable {
     private Date creationDate;
     private String status; // String representation of Trip.TripStatus
     private Long finalDestinationId;
+    private boolean evaluationMode;
+    private boolean finalized;
+    private boolean isHost;
+    private boolean canEnterFinalEvaluation;
 
     // Constructors
     public TripGetDTO() {
     }
 
-    public TripGetDTO(Long id, String name, String roomCode, Long hostId, Date creationDate, 
-                      String status, Long finalDestinationId) {
+    public TripGetDTO(Long id, String name, String roomCode, Long hostId, Date creationDate,
+                      String status, Long finalDestinationId,
+                      boolean evaluationMode, boolean finalized, boolean isHost, boolean canEnterFinalEvaluation) {
         this.id = id;
         this.name = name;
         this.roomCode = roomCode;
@@ -31,6 +36,10 @@ public class TripGetDTO implements Serializable {
         this.creationDate = creationDate;
         this.status = status;
         this.finalDestinationId = finalDestinationId;
+        this.evaluationMode = evaluationMode;
+        this.finalized = finalized;
+        this.isHost = isHost;
+        this.canEnterFinalEvaluation = canEnterFinalEvaluation;
     }
 
     // Getters and Setters
@@ -88,5 +97,37 @@ public class TripGetDTO implements Serializable {
 
     public void setFinalDestinationId(Long finalDestinationId) {
         this.finalDestinationId = finalDestinationId;
+    }
+
+    public boolean isEvaluationMode() {
+        return evaluationMode;
+    }
+
+    public void setEvaluationMode(boolean evaluationMode) {
+        this.evaluationMode = evaluationMode;
+    }
+
+    public boolean isFinalized() {
+        return finalized;
+    }
+
+    public void setFinalized(boolean finalized) {
+        this.finalized = finalized;
+    }
+
+    public boolean isHost() {
+        return isHost;
+    }
+
+    public void setHost(boolean host) {
+        isHost = host;
+    }
+
+    public boolean isCanEnterFinalEvaluation() {
+        return canEnterFinalEvaluation;
+    }
+
+    public void setCanEnterFinalEvaluation(boolean canEnterFinalEvaluation) {
+        this.canEnterFinalEvaluation = canEnterFinalEvaluation;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementService.java
@@ -1,7 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Activity;
-import ch.uzh.ifi.hase.soprafs26.entity.Trip;
 import ch.uzh.ifi.hase.soprafs26.entity.Vote;
 import ch.uzh.ifi.hase.soprafs26.entity.VoteType;
 import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
@@ -126,11 +125,8 @@ public class ActivityManagementService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid vote type. Use UP or DOWN.");
         }
 
-        // Ensure the trip is active and the user is a participant before allowing voting
-        Trip trip = tripService.getTripForParticipant(tripId, userId);
-        if (trip.getStatus() != Trip.TripStatus.ACTIVE) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Voting is only allowed while the trip is ACTIVE");
-        }
+        // Ensure the user is a participant and the trip is writable before allowing voting.
+        tripService.ensureTripWritableForParticipant(tripId, userId);
 
         destinationService.getDestinationEntity(tripId, destinationId);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -198,14 +198,52 @@ public class TripService {
      */
     public Trip updateTripStatus(Long tripId, Trip.TripStatus newStatus) {
         log.debug("Updating trip {} status to: {}", tripId, newStatus);
+        if (newStatus != Trip.TripStatus.EVALUATION) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Only transition to EVALUATION is supported via this endpoint"
+            );
+        }
 
         Trip trip = getTripById(tripId);
-        validateEvaluationTransition(trip, newStatus);
-        trip.setStatus(newStatus);
+        return enterFinalEvaluation(tripId, trip.getHostId());
+    }
 
+    /**
+     * Enter final evaluation mode for a trip.
+     * This transition is host-only and allowed only if the trip has at least one destination,
+     * is not already in EVALUATION, and is not FINALIZED.
+     * @param tripId target trip id
+     * @param actorUserId authenticated caller id
+     * @return updated trip in EVALUATION mode
+     */
+    public Trip enterFinalEvaluation(Long tripId, Long actorUserId) {
+        log.debug("User {} requested final evaluation for trip {}", actorUserId, tripId);
+
+        Trip trip = getTripById(tripId);
+
+        if (!trip.getHostId().equals(actorUserId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can enter final evaluation mode");
+        }
+
+        if (!destinationRepository.existsByTripId(tripId)) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "At least one destination is required before entering EVALUATION"
+            );
+        }
+
+        if (trip.getStatus() == Trip.TripStatus.EVALUATION) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Trip is already in EVALUATION mode");
+        }
+
+        if (trip.getStatus() == Trip.TripStatus.FINALIZED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Trip is FINALIZED and cannot enter EVALUATION");
+        }
+
+        trip.setStatus(Trip.TripStatus.EVALUATION);
         Trip updatedTrip = tripRepository.save(trip);
-        log.info("Trip {} status updated to: {}", tripId, newStatus);
-
+        log.info("Trip {} entered EVALUATION mode", tripId);
         return updatedTrip;
     }
 
@@ -347,30 +385,4 @@ public class TripService {
         destination.setDestinationName(destination.getDestinationName().trim());
     }
 
-    /**
-     * Validates whether the requested status transition is allowed for entering evaluation mode.
-     */
-    private void validateEvaluationTransition(Trip trip, Trip.TripStatus newStatus) {
-        if (newStatus != Trip.TripStatus.EVALUATION) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "Only transition to EVALUATION is supported via this endpoint"
-            );
-        }
-
-        if (trip.getStatus() == Trip.TripStatus.EVALUATION) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Trip is already in EVALUATION mode");
-        }
-
-        if (trip.getStatus() == Trip.TripStatus.FINALIZED) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Trip is FINALIZED and cannot enter EVALUATION");
-        }
-
-        if (destinationRepository.findByTripIdOrderByIdDesc(trip.getId()).isEmpty()) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "At least one destination is required before entering EVALUATION"
-            );
-        }
-    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -278,6 +278,26 @@ public class TripService {
     }
 
     /**
+     * Returns whether the caller may enter final evaluation right now.
+     * This is intended for UI state in trip responses.
+     * @param trip trip entity
+     * @param actorUserId authenticated caller id
+     * @return true if final evaluation can be entered
+     */
+    public boolean canEnterFinalEvaluation(Trip trip, Long actorUserId) {
+        if (trip == null || actorUserId == null) {
+            return false;
+        }
+        if (!trip.getHostId().equals(actorUserId)) {
+            return false;
+        }
+        if (trip.getStatus() == Trip.TripStatus.EVALUATION || trip.getStatus() == Trip.TripStatus.FINALIZED) {
+            return false;
+        }
+        return destinationRepository.existsByTripId(trip.getId());
+    }
+
+    /**
      * Set the final destination for a trip
      * @param tripId the ID of the trip
      * @param finalDestinationId the ID of the destination selected as final

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/TripService.java
@@ -162,7 +162,7 @@ public class TripService {
         Trip trip = getTripById(tripId);
         validateDestinationInput(destination);
         ensureParticipant(tripId, userId);
-        ensureTripIsActiveForMutations(trip);
+        ensureTripIsWritable(trip);
 
         destination.setTripId(tripId);
         destination.setProposedByUserId(userId);
@@ -253,12 +253,7 @@ public class TripService {
      * @param trip trip entity
      */
     public void ensureTripIsActiveForMutations(Trip trip) {
-        if (trip.getStatus() != Trip.TripStatus.ACTIVE) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "Trip is in read-only mode. Mutations are only allowed while trip is ACTIVE"
-            );
-        }
+        ensureTripIsWritable(trip);
     }
 
     /**
@@ -267,6 +262,19 @@ public class TripService {
      */
     public void ensureTripIsActiveForMutations(Long tripId) {
         ensureTripIsActiveForMutations(getTripById(tripId));
+    }
+
+    /**
+     * Shared participant + writable guard for mutation paths.
+     * @param tripId target trip id
+     * @param userId authenticated user id
+     * @return loaded trip entity
+     */
+    public Trip ensureTripWritableForParticipant(Long tripId, Long userId) {
+        Trip trip = getTripById(tripId);
+        ensureParticipant(tripId, userId);
+        ensureTripIsWritable(trip);
+        return trip;
     }
 
     /**
@@ -383,6 +391,15 @@ public class TripService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Destination name cannot be empty");
         }
         destination.setDestinationName(destination.getDestinationName().trim());
+    }
+
+    private void ensureTripIsWritable(Trip trip) {
+        if (trip.getStatus() != Trip.TripStatus.ACTIVE) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Trip is in read-only mode. Mutations are only allowed while trip is ACTIVE"
+            );
+        }
     }
 
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -226,8 +226,7 @@ public class TripControllerTest {
         trip.setStatus(Trip.TripStatus.EVALUATION);
 
         given(userService.validateToken("Bearer 1")).willReturn(authenticatedUser());
-        given(tripService.getTripById(1L)).willReturn(trip);
-        given(tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION)).willReturn(trip);
+        given(tripService.enterFinalEvaluation(1L, 1L)).willReturn(trip);
 
         // when
         MockHttpServletRequestBuilder putRequest = put("/trips/1/status")
@@ -256,7 +255,8 @@ public class TripControllerTest {
         trip.setStatus(Trip.TripStatus.ACTIVE);
 
         given(userService.validateToken("Bearer valid-token")).willReturn(nonHost);
-        given(tripService.getTripById(1L)).willReturn(trip);
+        given(tripService.enterFinalEvaluation(1L, 2L))
+                .willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can enter final evaluation mode"));
 
         // when
         MockHttpServletRequestBuilder putRequest = put("/trips/1/status")

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -270,6 +270,44 @@ public class TripControllerTest {
     }
 
     @Test
+    public void enterFinalEvaluation_validInput_success() throws Exception {
+        Trip trip = new Trip();
+        trip.setId(1L);
+        trip.setName("Paris Vacation");
+        trip.setRoomCode("ABC123");
+        trip.setHostId(1L);
+        trip.setStatus(Trip.TripStatus.EVALUATION);
+
+        given(userService.validateToken("Bearer 1")).willReturn(authenticatedUser());
+        given(tripService.enterFinalEvaluation(1L, 1L)).willReturn(trip);
+
+        MockHttpServletRequestBuilder postRequest = post("/trips/1/final-evaluation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer 1");
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("EVALUATION")));
+    }
+
+    @Test
+    public void enterFinalEvaluation_nonHost_forbidden() throws Exception {
+        User nonHost = new User();
+        nonHost.setId(2L);
+
+        given(userService.validateToken("Bearer valid-token")).willReturn(nonHost);
+        given(tripService.enterFinalEvaluation(1L, 2L))
+                .willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can enter final evaluation mode"));
+
+        MockHttpServletRequestBuilder postRequest = post("/trips/1/final-evaluation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer valid-token");
+
+        mockMvc.perform(postRequest)
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     public void setFinalDestination_validInput_success() throws Exception {
         // given
         Trip trip = new Trip();

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/TripControllerTest.java
@@ -107,6 +107,7 @@ public class TripControllerTest {
 
         given(userService.validateToken("Bearer 1")).willReturn(authenticatedUser());
         given(tripService.getTripById(1L)).willReturn(trip);
+        given(tripService.canEnterFinalEvaluation(trip, 1L)).willReturn(true);
 
         // when
         MockHttpServletRequestBuilder getRequest = get("/trips/1")
@@ -118,7 +119,11 @@ public class TripControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id", is(Math.toIntExact(trip.getId()))))
                 .andExpect(jsonPath("$.name", is(trip.getName())))
-                .andExpect(jsonPath("$.roomCode", is(trip.getRoomCode())));
+                .andExpect(jsonPath("$.roomCode", is(trip.getRoomCode())))
+                .andExpect(jsonPath("$.host", is(true)))
+                .andExpect(jsonPath("$.evaluationMode", is(false)))
+                .andExpect(jsonPath("$.finalized", is(false)))
+                .andExpect(jsonPath("$.canEnterFinalEvaluation", is(true)));
     }
 
     @Test
@@ -227,6 +232,7 @@ public class TripControllerTest {
 
         given(userService.validateToken("Bearer 1")).willReturn(authenticatedUser());
         given(tripService.enterFinalEvaluation(1L, 1L)).willReturn(trip);
+        given(tripService.canEnterFinalEvaluation(trip, 1L)).willReturn(false);
 
         // when
         MockHttpServletRequestBuilder putRequest = put("/trips/1/status")
@@ -287,7 +293,9 @@ public class TripControllerTest {
 
         mockMvc.perform(postRequest)
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", is("EVALUATION")));
+                .andExpect(jsonPath("$.status", is("EVALUATION")))
+                .andExpect(jsonPath("$.evaluationMode", is(true)))
+                .andExpect(jsonPath("$.canEnterFinalEvaluation", is(false)));
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityVotingTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityVotingTest.java
@@ -89,7 +89,7 @@ public class ActivityVotingTest {
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(100L, 1L, 2L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
             Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(testDestination);
         Mockito.when(voteRepository.findByActivityIdAndUserId(100L, 123L)).thenReturn(Optional.empty());
         Mockito.when(voteRepository.countByActivityIdAndVoteType(100L, VoteType.UP)).thenReturn(1L);
@@ -116,7 +116,7 @@ public class ActivityVotingTest {
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(100L, 1L, 2L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
             Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(testDestination);
         Mockito.when(voteRepository.findByActivityIdAndUserId(100L, 123L)).thenReturn(Optional.empty());
         Mockito.when(voteRepository.countByActivityIdAndVoteType(100L, VoteType.UP)).thenReturn(0L);
@@ -144,7 +144,7 @@ public class ActivityVotingTest {
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(100L, 1L, 2L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
             Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(testDestination);
         Mockito.when(voteRepository.findByActivityIdAndUserId(100L, 123L)).thenReturn(Optional.of(existingUpVote));
         Mockito.when(voteRepository.countByActivityIdAndVoteType(100L, VoteType.UP)).thenReturn(0L);
@@ -171,7 +171,7 @@ public class ActivityVotingTest {
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(100L, 1L, 2L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
             Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(testDestination);
         Mockito.when(voteRepository.findByActivityIdAndUserId(100L, 123L)).thenReturn(Optional.of(existingUpVote));
         Mockito.when(voteRepository.countByActivityIdAndVoteType(100L, VoteType.UP)).thenReturn(0L);
@@ -199,7 +199,9 @@ public class ActivityVotingTest {
         inactiveTrip.setStatus(Trip.TripStatus.FINALIZED);
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(inactiveTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenThrow(
+            new ResponseStatusException(org.springframework.http.HttpStatus.BAD_REQUEST,
+                "Trip is in read-only mode. Mutations are only allowed while trip is ACTIVE"));
 
         assertThrows(ResponseStatusException.class,
                 () -> activityManagementService.voteOnActivity(100L, 123L, voteRequest));
@@ -214,7 +216,7 @@ public class ActivityVotingTest {
         voteRequest.setVoteType("UP");
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L))
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L))
                 .thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.FORBIDDEN, "Not a participant"));
 
         assertThrows(ResponseStatusException.class,
@@ -244,7 +246,7 @@ public class ActivityVotingTest {
         voteRequest.setVoteType("INVALID");
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
 
         assertThrows(ResponseStatusException.class,
                 () -> activityManagementService.voteOnActivity(100L, 123L, voteRequest));
@@ -257,7 +259,7 @@ public class ActivityVotingTest {
     public void voteOnActivity_nullVoteRequest_throwsException() {
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(100L, 1L, 2L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
             Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(testDestination);
 
         assertThrows(ResponseStatusException.class,
@@ -274,7 +276,7 @@ public class ActivityVotingTest {
 
         Mockito.when(activityRepository.findById(100L)).thenReturn(Optional.of(testActivity));
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(100L, 1L, 2L)).thenReturn(Optional.of(testActivity));
-        Mockito.when(tripService.getTripForParticipant(1L, 123L)).thenReturn(testTrip);
+        Mockito.when(tripService.ensureTripWritableForParticipant(1L, 123L)).thenReturn(testTrip);
             Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(testDestination);
         Mockito.when(voteRepository.findByActivityIdAndUserId(100L, 123L)).thenReturn(Optional.empty());
         Mockito.when(voteRepository.countByActivityIdAndVoteType(100L, VoteType.UP)).thenReturn(5L);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -198,11 +198,7 @@ public class TripServiceTest {
     public void updateTripStatus_validInput_success() {
         // given
         Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
-        Destination existingDestination = new Destination();
-        existingDestination.setId(10L);
-        existingDestination.setTripId(1L);
-        existingDestination.setDestinationName("Zurich");
-        Mockito.when(destinationRepository.findByTripIdOrderByIdDesc(1L)).thenReturn(List.of(existingDestination));
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(true);
 
         // when
         Trip updatedTrip = tripService.updateTripStatus(1L, Trip.TripStatus.EVALUATION);
@@ -215,7 +211,7 @@ public class TripServiceTest {
     @Test
     public void updateTripStatus_noDestinations_badRequest() {
         Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
-        Mockito.when(destinationRepository.findByTripIdOrderByIdDesc(1L)).thenReturn(List.of());
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(false);
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
@@ -229,6 +225,7 @@ public class TripServiceTest {
     public void updateTripStatus_alreadyEvaluation_conflict() {
         testTrip.setStatus(Trip.TripStatus.EVALUATION);
         Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(true);
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
@@ -242,6 +239,7 @@ public class TripServiceTest {
     public void updateTripStatus_finalized_conflict() {
         testTrip.setStatus(Trip.TripStatus.FINALIZED);
         Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(true);
 
         ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
@@ -249,6 +247,18 @@ public class TripServiceTest {
         );
 
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+    }
+
+    @Test
+    public void enterFinalEvaluation_nonHost_forbidden() {
+        Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> tripService.enterFinalEvaluation(1L, 99L)
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/TripServiceTest.java
@@ -262,6 +262,33 @@ public class TripServiceTest {
     }
 
     @Test
+    public void canEnterFinalEvaluation_hostWithDestination_true() {
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(true);
+
+        boolean result = tripService.canEnterFinalEvaluation(testTrip, 1L);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void canEnterFinalEvaluation_nonHost_false() {
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(true);
+
+        boolean result = tripService.canEnterFinalEvaluation(testTrip, 99L);
+
+        assertEquals(false, result);
+    }
+
+    @Test
+    public void canEnterFinalEvaluation_noDestination_false() {
+        Mockito.when(destinationRepository.existsByTripId(1L)).thenReturn(false);
+
+        boolean result = tripService.canEnterFinalEvaluation(testTrip, 1L);
+
+        assertEquals(false, result);
+    }
+
+    @Test
     public void setFinalDestination_validInput_success() {
         // given
         Mockito.when(tripRepository.findById(1L)).thenReturn(Optional.of(testTrip));


### PR DESCRIPTION
- Add POST /trips/{tripId}/final-evaluation endpoint with host-only validation
- Implement centralized write-guard pattern blocking mutations in EVALUATION/FINALIZED states
- Apply guard to all Destination and Activity mutation endpoints
- Extend TripGetDTO with evaluation UI-state flags (evaluationMode, finalized, isHost, canEnterFinalEvaluation)
- Add service helper canEnterFinalEvaluation() for frontend button logic
- Add comprehensive tests for state transitions and vote guard enforcement