### PR TITLE
Fix prod Google Maps key injection and hide photo key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Validate required secrets
+        run: |
+          if [ -z "${{ secrets.GOOGLE_MAPS_API_KEY }}" ]; then
+            echo "::error::Missing required secret GOOGLE_MAPS_API_KEY."
+            exit 1
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
+
       - name: Deploy to App Engine
         id: deploy
-        uses: google-github-actions/deploy-appengine@v0.2.0
+        uses: google-github-actions/deploy-appengine@v3
         with:
           deliverables: app.yaml
           version: v1
-          credentials: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
+          env_vars: |
+            GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}
 
       - name: Test
-        run: curl "${{ steps.deploy.outputs.url }}"
+        run: curl "${{ steps.deploy.outputs.version_url }}"

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityController.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
 import ch.uzh.ifi.hase.soprafs26.service.ActivitySearchService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -97,6 +98,13 @@ public class ActivityController {
                                                                 @RequestHeader(value = "Authorization", required = false) String token) {
         userService.validateToken(token);
         return activitySearchService.searchActivities(null, null, query, location, radius);
+    }
+
+    @GetMapping("/activities/photo")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<byte[]> getActivityPhoto(@RequestParam("photoReference") String photoReference,
+                                                   @RequestParam(value = "maxwidth", required = false) Integer maxWidth) {
+        return activitySearchService.fetchPhoto(photoReference, maxWidth);
     }
 
     private static Activity toActivityEntity(ActivityPostDTO activityPostDTO) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivitySearchService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivitySearchService.java
@@ -4,11 +4,14 @@ import ch.uzh.ifi.hase.soprafs26.config.GoogleMapsProperties;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriComponentsBuilder;
 import tools.jackson.databind.ObjectMapper;
@@ -103,6 +106,39 @@ public class ActivitySearchService {
             throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
                     "Failed to parse activity search response", ex);
         }
+    }
+
+    public ResponseEntity<byte[]> fetchPhoto(String photoReference, Integer maxWidth) {
+        if (photoReference == null || photoReference.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Photo reference cannot be empty");
+        }
+
+        if (apiKey == null || apiKey.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Google Maps API key is not configured");
+        }
+
+        int width = (maxWidth != null && maxWidth > 0 && maxWidth <= 1600) ? maxWidth : 800;
+        String requestUrl = UriComponentsBuilder.fromUriString("https://maps.googleapis.com/maps/api/place/photo")
+                .queryParam("maxwidth", width)
+                .queryParam("photo_reference", photoReference.trim())
+                .queryParam("key", apiKey.trim())
+                .toUriString();
+
+        ResponseEntity<byte[]> response = restTemplate.getForEntity(requestUrl, byte[].class);
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                    "Activity photo provider returned an invalid response");
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        MediaType contentType = response.getHeaders().getContentType();
+        headers.setContentType(contentType != null ? contentType : MediaType.APPLICATION_OCTET_STREAM);
+        long contentLength = response.getHeaders().getContentLength();
+        if (contentLength > 0) {
+            headers.setContentLength(contentLength);
+        }
+        return new ResponseEntity<>(response.getBody(), headers, HttpStatus.OK);
     }
 
     private ActivitySearchResultDTO mapResult(GooglePlacesResult resultNode) {
@@ -275,11 +311,19 @@ public class ActivitySearchService {
             return null;
         }
 
-        return UriComponentsBuilder.fromUriString("https://maps.googleapis.com/maps/api/place/photo")
-                .queryParam("maxwidth", 800)
-                .queryParam("photo_reference", resultNode.getPhotos().get(0).getPhotoReference())
-                .queryParam("key", apiKey.trim())
-                .toUriString();
+        String photoReference = resultNode.getPhotos().get(0).getPhotoReference();
+        try {
+            return ServletUriComponentsBuilder.fromCurrentContextPath()
+                    .path("/activities/photo")
+                    .queryParam("photoReference", photoReference)
+                    .queryParam("maxwidth", 800)
+                    .toUriString();
+        } catch (IllegalStateException ex) {
+            return UriComponentsBuilder.fromPath("/activities/photo")
+                    .queryParam("photoReference", photoReference)
+                    .queryParam("maxwidth", 800)
+                    .toUriString();
+        }
     }
 
     private static String redactApiKey(String url) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivitySearchServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivitySearchServiceTest.java
@@ -73,7 +73,7 @@ public class ActivitySearchServiceTest {
         assertEquals("City Museum", results.get(0).getName());
         assertEquals("Main Street 1", results.get(0).getAddress());
         assertEquals(4.6, results.get(0).getRating());
-        assertEquals("https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photo_reference=photo-ref-1&key=test-key", results.get(0).getPhotoUrl());
+        assertEquals("/activities/photo?photoReference=photo-ref-1&maxwidth=800", results.get(0).getPhotoUrl());
         assertEquals(47.3769, results.get(0).getLatitude());
         assertEquals(8.5417, results.get(0).getLongitude());
     }


### PR DESCRIPTION
## Summary
- inject GOOGLE_MAPS_API_KEY into App Engine deploy workflow from GitHub Secrets
- add backend /activities/photo proxy endpoint for Google photo bytes
- return backend photo proxy URLs from activity search instead of Google URLs with key
- update tests for key-hiding behavior

## Validation
- ActivitySearchServiceTest passes locally
- public activity search verified before and after key setup