### PR TITLE
Implement activity deletion backend flow, US12

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityController.java
@@ -1,5 +1,20 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
 import ch.uzh.ifi.hase.soprafs26.entity.Activity;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityPostDTO;
@@ -9,20 +24,6 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteResponseDTO;
 import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
 import ch.uzh.ifi.hase.soprafs26.service.ActivitySearchService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.DeleteMapping;
-
-import java.util.List;
 
 @RestController
 public class ActivityController {
@@ -148,6 +149,7 @@ public class ActivityController {
         resultDTO.setPhotoUrl(activity.getPhotoUrl());
         resultDTO.setLatitude(activity.getLatitude());
         resultDTO.setLongitude(activity.getLongitude());
+        resultDTO.setCreatedBy(activity.getCreatedBy());
         
         // Populate vote data if user is authenticated
         if (userId != null) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/DestinationController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/DestinationController.java
@@ -1,18 +1,10 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
-import ch.uzh.ifi.hase.soprafs26.entity.Activity;
-import ch.uzh.ifi.hase.soprafs26.entity.Destination;
-import ch.uzh.ifi.hase.soprafs26.entity.User;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationGetDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationPostDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
-import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
-import ch.uzh.ifi.hase.soprafs26.service.DestinationRealtimeService;
-import ch.uzh.ifi.hase.soprafs26.service.DestinationService;
-import ch.uzh.ifi.hase.soprafs26.service.TripService;
-import ch.uzh.ifi.hase.soprafs26.service.UserService;
-import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,13 +17,22 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import org.springframework.context.event.EventListener;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Destination;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.event.DestinationVotesUpdatedEvent;
 import ch.uzh.ifi.hase.soprafs26.event.TripStatusUpdatedEvent;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
+import ch.uzh.ifi.hase.soprafs26.service.DestinationRealtimeService;
+import ch.uzh.ifi.hase.soprafs26.service.DestinationService;
+import ch.uzh.ifi.hase.soprafs26.service.TripService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
 
 @RestController
 public class DestinationController {
@@ -175,6 +176,7 @@ public class DestinationController {
         resultDTO.setPhotoUrl(activity.getPhotoUrl());
         resultDTO.setLatitude(activity.getLatitude());
         resultDTO.setLongitude(activity.getLongitude());
+        resultDTO.setCreatedBy(activity.getCreatedBy());
         
         // Populate vote data if user is authenticated
         if (userId != null) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Activity.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Activity.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.entity;
 
+import java.io.Serializable;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -7,8 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-
-import java.io.Serializable;
 
 @Entity
 @Table(name = "ACTIVITY", uniqueConstraints = {
@@ -48,6 +48,9 @@ public class Activity implements Serializable {
 
     @Column
     private Double longitude;
+
+    @Column(nullable = false)
+    private Long createdBy;
 
     public Long getId() {
         return id;
@@ -127,5 +130,13 @@ public class Activity implements Serializable {
 
     public void setLongitude(Double longitude) {
         this.longitude = longitude;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ActivitySearchResultDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/ActivitySearchResultDTO.java
@@ -14,6 +14,7 @@ public class ActivitySearchResultDTO implements Serializable {
     private String photoUrl;
     private Double latitude;
     private Double longitude;
+    private Long createdBy;
     private long upvotes;
     private long downvotes;
     private long score;
@@ -81,6 +82,14 @@ public class ActivitySearchResultDTO implements Serializable {
 
     public void setLongitude(Double longitude) {
         this.longitude = longitude;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
     }
 
     public long getUpvotes() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementService.java
@@ -1,22 +1,23 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.entity.Activity;
-import ch.uzh.ifi.hase.soprafs26.entity.Vote;
-import ch.uzh.ifi.hase.soprafs26.entity.VoteType;
-import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
-import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteRequestDTO;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteResponseDTO;
-import ch.uzh.ifi.hase.soprafs26.event.DestinationVotesUpdatedEvent;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
-import java.util.Optional;
+import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Vote;
+import ch.uzh.ifi.hase.soprafs26.entity.VoteType;
+import ch.uzh.ifi.hase.soprafs26.event.DestinationVotesUpdatedEvent;
+import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteRequestDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteResponseDTO;
 
 @Service
 @Transactional
@@ -66,6 +67,7 @@ public class ActivityManagementService {
         activity.setPhotoUrl(activityInput.getPhotoUrl());
         activity.setLatitude(activityInput.getLatitude());
         activity.setLongitude(activityInput.getLongitude());
+        activity.setCreatedBy(userId);
 
         Activity saved = activityRepository.save(activity);
         eventPublisher.publishEvent(new DestinationVotesUpdatedEvent(this, tripId, userId));
@@ -99,6 +101,14 @@ public class ActivityManagementService {
 
         Activity activity = activityRepository.findByIdAndTripIdAndDestinationId(activityId, tripId, destinationId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Activity not found"));
+
+        if (!activity.getCreatedBy().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the creator can delete this activity");
+        }
+
+        if (voteRepository.countByActivityIdAndVoteType(activity.getId(), VoteType.UP) > 0 ) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot delete activity with existing votes");
+        }
 
         activityRepository.delete(activity);
         eventPublisher.publishEvent(new DestinationVotesUpdatedEvent(this, tripId, userId));

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityControllerTest.java
@@ -1,5 +1,23 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
+
 import ch.uzh.ifi.hase.soprafs26.entity.Activity;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityPostDTO;
@@ -7,23 +25,7 @@ import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
 import ch.uzh.ifi.hase.soprafs26.service.ActivitySearchService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import tools.jackson.databind.ObjectMapper;
-
-import java.util.List;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class ActivityControllerTest {
 
@@ -178,6 +180,72 @@ public class ActivityControllerTest {
                             .header("Authorization", "Bearer token")
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isNoContent());
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    // #222
+    @Test
+    public void deleteActivity_notCreator_returns403() {
+        User user = new User();
+        user.setId(1L);
+
+        Mockito.when(userService.validateToken("Bearer token")).thenReturn(user);
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the creator can delete this activity"))
+                .when(activityManagementService).deleteActivity(1L, 2L, 10L, 1L);
+
+        try {
+            mockMvc.perform(delete("/trips/1/destinations/2/activities/10")
+                            .header("Authorization", "Bearer token")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isForbidden());
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    // #223
+    @Test
+    public void deleteActivity_hasUpvotes_returns400() {
+        User user = new User();
+        user.setId(1L);
+
+        Mockito.when(userService.validateToken("Bearer token")).thenReturn(user);
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot delete activity with existing votes"))
+                .when(activityManagementService).deleteActivity(1L, 2L, 10L, 1L);
+
+        try {
+            mockMvc.perform(delete("/trips/1/destinations/2/activities/10")
+                            .header("Authorization", "Bearer token")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest());
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    // #122
+    @Test
+    public void getSavedActivities_includesCreatedBy_inResponse() {
+        User user = new User();
+        user.setId(1L);
+
+        Activity activity = new Activity();
+        activity.setId(10L);
+        activity.setPlaceId("place-1");
+        activity.setName("Museum");
+        activity.setCreatedBy(42L);
+
+        Mockito.when(userService.validateToken("Bearer token")).thenReturn(user);
+        Mockito.when(activityManagementService.getSelectedActivities(1L, 2L)).thenReturn(List.of(activity));
+
+        try {
+            mockMvc.perform(get("/trips/1/destinations/2/activities")
+                            .header("Authorization", "Bearer token")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].createdBy").value(42));
         } catch (Exception exception) {
             throw new RuntimeException(exception);
         }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/ActivityManagementServiceTest.java
@@ -1,23 +1,25 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.entity.Activity;
-import ch.uzh.ifi.hase.soprafs26.entity.Destination;
-import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
-import org.springframework.context.ApplicationEventPublisher;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Destination;
+import ch.uzh.ifi.hase.soprafs26.entity.VoteType;
+import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 
 public class ActivityManagementServiceTest {
 
@@ -29,6 +31,9 @@ public class ActivityManagementServiceTest {
 
     @Mock
     private TripService tripService;
+
+    @Mock
+    private VoteRepository voteRepository;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -147,6 +152,29 @@ public class ActivityManagementServiceTest {
         existing.setId(10L);
         existing.setTripId(1L);
         existing.setDestinationId(2L);
+        existing.setCreatedBy(100L);
+
+        Destination destination = new Destination();
+        destination.setId(2L);
+        destination.setTripId(1L);
+
+        Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(destination);
+        Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(existing));
+        Mockito.when(voteRepository.countByActivityIdAndVoteType(10L, VoteType.UP)).thenReturn(0L);
+        Mockito.when(voteRepository.countByActivityIdAndVoteType(10L, VoteType.DOWN)).thenReturn(0L);
+
+        activityManagementService.deleteActivity(1L, 2L, 10L, 100L);
+
+        Mockito.verify(activityRepository, Mockito.times(1)).delete(existing);
+    }
+
+    @Test
+    public void deleteActivity_nonCreator_forbidden() {
+        Activity existing = new Activity();
+        existing.setId(10L);
+        existing.setTripId(1L);
+        existing.setDestinationId(2L);
+        existing.setCreatedBy(111L);
 
         Destination destination = new Destination();
         destination.setId(2L);
@@ -155,9 +183,34 @@ public class ActivityManagementServiceTest {
         Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(destination);
         Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(existing));
 
-        activityManagementService.deleteActivity(1L, 2L, 10L, 100L);
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> activityManagementService.deleteActivity(1L, 2L, 10L, 100L));
 
-        Mockito.verify(activityRepository, Mockito.times(1)).delete(existing);
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        Mockito.verify(activityRepository, Mockito.never()).delete(Mockito.any(Activity.class));
+    }
+
+    @Test
+    public void deleteActivity_withUpvotes_badRequest() {
+        Activity existing = new Activity();
+        existing.setId(10L);
+        existing.setTripId(1L);
+        existing.setDestinationId(2L);
+        existing.setCreatedBy(100L);
+
+        Destination destination = new Destination();
+        destination.setId(2L);
+        destination.setTripId(1L);
+
+        Mockito.when(destinationService.getDestinationEntity(1L, 2L)).thenReturn(destination);
+        Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(existing));
+        Mockito.when(voteRepository.countByActivityIdAndVoteType(10L, VoteType.UP)).thenReturn(1L);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> activityManagementService.deleteActivity(1L, 2L, 10L, 100L));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        Mockito.verify(activityRepository, Mockito.never()).delete(Mockito.any(Activity.class));
     }
 
     @Test


### PR DESCRIPTION
[BE] Check that the activity exists before deletion #213

[BE] Ensure only the creator of the activity can delete it #214

[BE] Prevent deletion if the activity has already received upvotes #215

[BE] Remove the activity from persistence after confirmation #216

[TEST] Write backend tests for successful activity deletion #222

[TEST] Write backend tests for forbidden deletion after upvotes or by non-owner #223