### PR TITLE
Feature/US11-be-comment-on-activity-modified

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityController.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Activity;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.entity.Comment;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteRequestDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityVoteResponseDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.CommentGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.CommentPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
 import ch.uzh.ifi.hase.soprafs26.service.ActivitySearchService;
+import ch.uzh.ifi.hase.soprafs26.service.CommentService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 
 @RestController
@@ -30,13 +35,16 @@ public class ActivityController {
 
     private final ActivitySearchService activitySearchService;
     private final ActivityManagementService activityManagementService;
+    private final CommentService commentService;
     private final UserService userService;
 
     public ActivityController(ActivitySearchService activitySearchService,
                               ActivityManagementService activityManagementService,
+                              CommentService commentService,
                               UserService userService) {
         this.activitySearchService = activitySearchService;
         this.activityManagementService = activityManagementService;
+        this.commentService = commentService;
         this.userService = userService;
     }
 
@@ -91,6 +99,31 @@ public class ActivityController {
                                                 @RequestHeader(value = "Authorization", required = false) String token) {
         var requester = userService.validateToken(token);
         return activityManagementService.voteOnActivity(activityId, requester.getId(), voteRequest);
+    }
+
+    @GetMapping("/trips/{tripId}/destinations/{destinationId}/activities/{activityId}/comments")
+    @ResponseStatus(HttpStatus.OK)
+    public List<CommentGetDTO> getComments(@PathVariable("tripId") Long tripId,
+                                           @PathVariable("destinationId") Long destinationId,
+                                           @PathVariable("activityId") Long activityId,
+                                           @RequestHeader(value = "Authorization", required = false) String token) {
+        User requester = userService.validateToken(token);
+        return commentService.getComments(tripId, destinationId, activityId, requester.getId()).stream()
+                .map(comment -> toCommentGetDTO(comment))
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/trips/{tripId}/destinations/{destinationId}/activities/{activityId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommentGetDTO addComment(@PathVariable("tripId") Long tripId,
+                                    @PathVariable("destinationId") Long destinationId,
+                                    @PathVariable("activityId") Long activityId,
+                                    @RequestBody CommentPostDTO commentPostDTO,
+                                    @RequestHeader(value = "Authorization", required = false) String token) {
+        User requester = userService.validateToken(token);
+        Comment saved = commentService.addComment(tripId, destinationId, activityId, requester.getId(),
+                commentPostDTO != null ? commentPostDTO.getContent() : null);
+        return toCommentGetDTO(saved);
     }
 
     @DeleteMapping("/trips/{tripId}/destinations/{destinationId}/activities/{activityId}")
@@ -157,5 +190,19 @@ public class ActivityController {
         }
         
         return resultDTO;
+    }
+
+    private CommentGetDTO toCommentGetDTO(Comment comment) {
+        CommentGetDTO dto = new CommentGetDTO();
+        dto.setId(comment.getId());
+        dto.setTripId(comment.getTripId());
+        dto.setDestinationId(comment.getDestinationId());
+        dto.setActivityId(comment.getActivityId());
+        dto.setUserId(comment.getUserId());
+        dto.setContent(comment.getContent());
+        dto.setCreatedAt(comment.getCreatedAt());
+        User commenter = userService.getUserById(comment.getUserId());
+        dto.setUsername(commenter.getUsername());
+        return dto;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Comment.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Comment.java
@@ -1,0 +1,96 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "COMMENT")
+public class Comment implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tripId;
+
+    @Column(nullable = false)
+    private Long destinationId;
+
+    @Column(nullable = false)
+    private Long activityId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 280)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getTripId() {
+        return tripId;
+    }
+
+    public void setTripId(Long tripId) {
+        this.tripId = tripId;
+    }
+
+    public Long getDestinationId() {
+        return destinationId;
+    }
+
+    public void setDestinationId(Long destinationId) {
+        this.destinationId = destinationId;
+    }
+
+    public Long getActivityId() {
+        return activityId;
+    }
+
+    public void setActivityId(Long activityId) {
+        this.activityId = activityId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Comment.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Comment.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "COMMENT")
+@Table(name = "COMMENTS")
 public class Comment implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/CommentRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository("commentRepository")
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByTripIdAndDestinationIdAndActivityIdOrderByCreatedAtAsc(Long tripId, Long destinationId, Long activityId);
+
+    List<Comment> findByActivityIdOrderByCreatedAtAsc(Long activityId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CommentGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CommentGetDTO.java
@@ -1,0 +1,79 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.LocalDateTime;
+
+public class CommentGetDTO {
+
+    private Long id;
+    private Long tripId;
+    private Long destinationId;
+    private Long activityId;
+    private Long userId;
+    private String username;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getTripId() {
+        return tripId;
+    }
+
+    public void setTripId(Long tripId) {
+        this.tripId = tripId;
+    }
+
+    public Long getDestinationId() {
+        return destinationId;
+    }
+
+    public void setDestinationId(Long destinationId) {
+        this.destinationId = destinationId;
+    }
+
+    public Long getActivityId() {
+        return activityId;
+    }
+
+    public void setActivityId(Long activityId) {
+        this.activityId = activityId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CommentPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CommentPostDTO.java
@@ -1,0 +1,14 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class CommentPostDTO {
+
+    private String content;
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CommentService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CommentService.java
@@ -1,0 +1,73 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Comment;
+import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.CommentRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+public class CommentService {
+
+    private static final int MAX_COMMENT_LENGTH = 280;
+
+    private final CommentRepository commentRepository;
+    private final ActivityRepository activityRepository;
+    private final TripService tripService;
+
+    public CommentService(CommentRepository commentRepository,
+                          ActivityRepository activityRepository,
+                          TripService tripService) {
+        this.commentRepository = commentRepository;
+        this.activityRepository = activityRepository;
+        this.tripService = tripService;
+    }
+
+    public Comment addComment(Long tripId, Long destinationId, Long activityId, Long userId, String content) {
+        tripService.getTripForParticipant(tripId, userId);
+
+        Activity activity = activityRepository.findByIdAndTripIdAndDestinationId(activityId, tripId, destinationId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Activity not found"));
+
+        String normalizedContent = validateAndNormalizeContent(content);
+
+        Comment comment = new Comment();
+        comment.setTripId(tripId);
+        comment.setDestinationId(destinationId);
+        comment.setActivityId(activity.getId());
+        comment.setUserId(userId);
+        comment.setContent(normalizedContent);
+        comment.setCreatedAt(LocalDateTime.now());
+
+        return commentRepository.save(comment);
+    }
+
+    public List<Comment> getComments(Long tripId, Long destinationId, Long activityId, Long userId) {
+        tripService.getTripForParticipant(tripId, userId);
+
+        activityRepository.findByIdAndTripIdAndDestinationId(activityId, tripId, destinationId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Activity not found"));
+
+        return commentRepository.findByTripIdAndDestinationIdAndActivityIdOrderByCreatedAtAsc(tripId, destinationId, activityId);
+    }
+
+    private String validateAndNormalizeContent(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Comment content cannot be empty");
+        }
+
+        String normalizedContent = content.trim();
+        if (normalizedContent.length() > MAX_COMMENT_LENGTH) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Comment content cannot exceed 280 characters");
+        }
+
+        return normalizedContent;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/ActivityControllerTest.java
@@ -19,11 +19,14 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.server.ResponseStatusException;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Comment;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivityPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.ActivitySearchResultDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.CommentPostDTO;
 import ch.uzh.ifi.hase.soprafs26.service.ActivityManagementService;
 import ch.uzh.ifi.hase.soprafs26.service.ActivitySearchService;
+import ch.uzh.ifi.hase.soprafs26.service.CommentService;
 import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import tools.jackson.databind.ObjectMapper;
 
@@ -36,6 +39,9 @@ public class ActivityControllerTest {
     private ActivityManagementService activityManagementService;
 
     @Mock
+    private CommentService commentService;
+
+    @Mock
     private UserService userService;
 
     private ActivityController activityController;
@@ -45,7 +51,7 @@ public class ActivityControllerTest {
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        activityController = new ActivityController(activitySearchService, activityManagementService, userService);
+        activityController = new ActivityController(activitySearchService, activityManagementService, commentService, userService);
         mockMvc = MockMvcBuilders.standaloneSetup(activityController).build();
     }
 
@@ -219,6 +225,98 @@ public class ActivityControllerTest {
             mockMvc.perform(delete("/trips/1/destinations/2/activities/10")
                             .header("Authorization", "Bearer token")
                             .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest());
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    @Test
+    public void addComment_validPayload_success() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+
+        CommentPostDTO postDTO = new CommentPostDTO();
+        postDTO.setContent("Looks amazing");
+
+        Comment saved = new Comment();
+        saved.setId(99L);
+        saved.setTripId(1L);
+        saved.setDestinationId(2L);
+        saved.setActivityId(10L);
+        saved.setUserId(1L);
+        saved.setContent("Looks amazing");
+        saved.setCreatedAt(java.time.LocalDateTime.of(2026, 5, 3, 12, 0));
+
+        Mockito.when(userService.validateToken("Bearer token")).thenReturn(user);
+        Mockito.when(commentService.addComment(1L, 2L, 10L, 1L, "Looks amazing")).thenReturn(saved);
+        Mockito.when(userService.getUserById(1L)).thenReturn(user);
+
+        try {
+            mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/trips/1/destinations/2/activities/10/comments")
+                            .header("Authorization", "Bearer token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new ObjectMapper().writeValueAsString(postDTO)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").value(99))
+                    .andExpect(jsonPath("$.userId").value(1))
+                    .andExpect(jsonPath("$.username").value("alice"))
+                    .andExpect(jsonPath("$.content").value("Looks amazing"));
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    @Test
+    public void getComments_success() {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+
+        Comment first = new Comment();
+        first.setId(1L);
+        first.setTripId(1L);
+        first.setDestinationId(2L);
+        first.setActivityId(10L);
+        first.setUserId(1L);
+        first.setContent("First comment");
+        first.setCreatedAt(java.time.LocalDateTime.of(2026, 5, 3, 11, 30));
+
+        Mockito.when(userService.validateToken("Bearer token")).thenReturn(user);
+        Mockito.when(commentService.getComments(1L, 2L, 10L, 1L)).thenReturn(List.of(first));
+        Mockito.when(userService.getUserById(1L)).thenReturn(user);
+
+        try {
+            mockMvc.perform(get("/trips/1/destinations/2/activities/10/comments")
+                            .header("Authorization", "Bearer token")
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").value(1))
+                    .andExpect(jsonPath("$[0].username").value("alice"))
+                    .andExpect(jsonPath("$[0].content").value("First comment"));
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    @Test
+    public void addComment_emptyContent_returns400() {
+        User user = new User();
+        user.setId(1L);
+
+        CommentPostDTO postDTO = new CommentPostDTO();
+        postDTO.setContent("   ");
+
+        Mockito.when(userService.validateToken("Bearer token")).thenReturn(user);
+        Mockito.when(commentService.addComment(1L, 2L, 10L, 1L, "   "))
+                .thenThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Comment content cannot be empty"));
+
+        try {
+            mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/trips/1/destinations/2/activities/10/comments")
+                            .header("Authorization", "Bearer token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new ObjectMapper().writeValueAsString(postDTO)))
                     .andExpect(status().isBadRequest());
         } catch (Exception exception) {
             throw new RuntimeException(exception);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CommentServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CommentServiceTest.java
@@ -67,7 +67,12 @@ public class CommentServiceTest {
 
     @Test
     public void addComment_emptyContent_throwsBadRequest() {
-        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(new Trip());
+        Trip trip = new Trip();
+        Activity activity = new Activity();
+        activity.setId(10L);
+
+        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(trip);
+        Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(activity));
 
         ResponseStatusException exception = assertThrows(ResponseStatusException.class,
                 () -> commentService.addComment(1L, 2L, 10L, 100L, "   "));
@@ -77,7 +82,12 @@ public class CommentServiceTest {
 
     @Test
     public void addComment_tooLong_throwsBadRequest() {
-        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(new Trip());
+        Trip trip = new Trip();
+        Activity activity = new Activity();
+        activity.setId(10L);
+
+        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(trip);
+        Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(activity));
 
         String longComment = "a".repeat(281);
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CommentServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CommentServiceTest.java
@@ -1,0 +1,120 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Comment;
+import ch.uzh.ifi.hase.soprafs26.entity.Trip;
+import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.CommentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private TripService tripService;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void addComment_validInput_success() {
+        Trip trip = new Trip();
+        trip.setId(1L);
+
+        Activity activity = new Activity();
+        activity.setId(10L);
+        activity.setTripId(1L);
+        activity.setDestinationId(2L);
+
+        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(trip);
+        Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(activity));
+        Mockito.when(commentRepository.save(Mockito.any(Comment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Comment result = commentService.addComment(1L, 2L, 10L, 100L, "  Nice place  ");
+
+        assertEquals(1L, result.getTripId());
+        assertEquals(2L, result.getDestinationId());
+        assertEquals(10L, result.getActivityId());
+        assertEquals(100L, result.getUserId());
+        assertEquals("Nice place", result.getContent());
+        assertNotNull(result.getCreatedAt());
+    }
+
+    @Test
+    public void addComment_emptyContent_throwsBadRequest() {
+        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(new Trip());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> commentService.addComment(1L, 2L, 10L, 100L, "   "));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    public void addComment_tooLong_throwsBadRequest() {
+        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(new Trip());
+
+        String longComment = "a".repeat(281);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> commentService.addComment(1L, 2L, 10L, 100L, longComment));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    public void getComments_success() {
+        Trip trip = new Trip();
+        trip.setId(1L);
+
+        Activity activity = new Activity();
+        activity.setId(10L);
+        activity.setTripId(1L);
+        activity.setDestinationId(2L);
+
+        Comment comment = new Comment();
+        comment.setId(5L);
+        comment.setTripId(1L);
+        comment.setDestinationId(2L);
+        comment.setActivityId(10L);
+        comment.setUserId(100L);
+        comment.setContent("Hello");
+
+        Mockito.when(tripService.getTripForParticipant(1L, 100L)).thenReturn(trip);
+        Mockito.when(activityRepository.findByIdAndTripIdAndDestinationId(10L, 1L, 2L)).thenReturn(Optional.of(activity));
+        Mockito.when(commentRepository.findByTripIdAndDestinationIdAndActivityIdOrderByCreatedAtAsc(1L, 2L, 10L))
+                .thenReturn(List.of(comment));
+
+        List<Comment> result = commentService.getComments(1L, 2L, 10L, 100L);
+
+        assertEquals(1, result.size());
+        assertEquals("Hello", result.get(0).getContent());
+        Mockito.verify(commentRepository, Mockito.times(1))
+                .findByTripIdAndDestinationIdAndActivityIdOrderByCreatedAtAsc(1L, 2L, 10L);
+    }
+}


### PR DESCRIPTION
ID: US-11
Story: As a user in a trip room, I want to comment on the activity.
Acceptance Criteria:
• By clicking on the activity, the user can leave a comment to explain or express what he’s thinking about the activity.
• This comment is shown next to the activity.
• The comment has a max. Number of characters, so that it doesn’t disturb the layout.

Re- implementation of the comment functionality for activities to allow for multiple users to comment . Addresses Issue #11. Fixes #11

Expanded Issues #198, #199, #200, #201, #202, #203, #209, #210


US-11 Development Tasks
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/198
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/199
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/200
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/201
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/202
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/203
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/209
    https://github.com/WasistdennmitKarstenlos/sopra-fs26-group-38-server/issues/210
