### PR TITLE
Add destination delete authorization and activity constraints

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/DestinationController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/DestinationController.java
@@ -147,8 +147,14 @@ public class DestinationController {
     public void deleteDestination(@PathVariable("tripId") Long tripId,
                                   @PathVariable("destinationId") Long destinationId,
                                   @RequestHeader(value = "Authorization", required = false) String token) {
-        userService.validateToken(token);
-        destinationService.deleteDestination(tripId, destinationId);
+        User requester = userService.validateToken(token);
+        destinationService.deleteDestination(tripId, destinationId, requester.getId());
+
+        // Real-time update to all clients
+        if (destinationRealtimeService != null) {
+            List<DestinationGetDTO> sharedList = buildSharedDestinationList(tripId, requester.getId());
+            destinationRealtimeService.publish(tripId, sharedList);
+        }
     }
 
     private List<DestinationGetDTO> buildSharedDestinationList(Long tripId, Long requesterId) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/DestinationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/DestinationService.java
@@ -70,9 +70,22 @@ public class DestinationService {
         return destinationRepository.save(destination);
     }
 
-    public void deleteDestination(Long tripId, Long destinationId) {
+    public void deleteDestination(Long tripId, Long destinationId, Long requesterId) {
         tripService.ensureTripIsActiveForMutations(tripId);
         Destination destination = getDestinationEntity(tripId, destinationId);
+
+        // Validation 1: Only creator can delete
+        Long proposedBy = destination.getProposedByUserId();
+        if (proposedBy == null || !proposedBy.equals(requesterId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the creator can delete this destination");
+        }
+
+        // Validation 2: Destination must not have activities
+        List<Activity> activities = activityRepository.findByTripIdAndDestinationIdOrderByIdDesc(tripId, destinationId);
+        if (!activities.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Destination has associated activities and cannot be deleted");
+        }
+
         destinationRepository.delete(destination);
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/DestinationControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/DestinationControllerTest.java
@@ -354,7 +354,7 @@ public class DestinationControllerTest {
                         .header("Authorization", "Bearer token"))
                 .andExpect(status().isNoContent());
 
-        verify(destinationService).deleteDestination(1L, 11L);
+        verify(destinationService).deleteDestination(1L, 11L, 1L);
     }
 
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceTest.java
@@ -91,7 +91,7 @@ public class DestinationServiceTest {
         Mockito.doThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "read-only"))
                 .when(tripService).ensureTripIsActiveForMutations(1L);
 
-        assertThrows(ResponseStatusException.class, () -> destinationService.deleteDestination(1L, 11L));
+        assertThrows(ResponseStatusException.class, () -> destinationService.deleteDestination(1L, 11L, 1L));
         Mockito.verifyNoInteractions(destinationRepository);
     }
 
@@ -188,5 +188,63 @@ public class DestinationServiceTest {
         assertEquals(1L, dto.getDownvotes());
         assertEquals(1L, dto.getScore());
         assertNull(dto.getUserVote());
+    }
+
+    @Test
+    public void deleteDestination_success() {
+        Destination existing = new Destination();
+        existing.setId(11L);
+        existing.setTripId(1L);
+        existing.setProposedByUserId(1L);
+        existing.setDestinationName("Paris");
+
+        Mockito.when(destinationRepository.findByIdAndTripId(11L, 1L)).thenReturn(Optional.of(existing));
+        Mockito.when(activityRepository.findByTripIdAndDestinationIdOrderByIdDesc(1L, 11L))
+                .thenReturn(List.of());
+
+        destinationService.deleteDestination(1L, 11L, 1L);
+
+        Mockito.verify(destinationRepository, Mockito.times(1)).delete(existing);
+    }
+
+    @Test
+    public void deleteDestination_forbidden_notCreator() {
+        Destination existing = new Destination();
+        existing.setId(11L);
+        existing.setTripId(1L);
+        existing.setProposedByUserId(1L);
+        existing.setDestinationName("Paris");
+
+        Mockito.when(destinationRepository.findByIdAndTripId(11L, 1L)).thenReturn(Optional.of(existing));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> destinationService.deleteDestination(1L, 11L, 2L));
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        Mockito.verify(destinationRepository, Mockito.never()).delete(Mockito.any());
+    }
+
+    @Test
+    public void deleteDestination_conflict_hasActivities() {
+        Destination existing = new Destination();
+        existing.setId(11L);
+        existing.setTripId(1L);
+        existing.setProposedByUserId(1L);
+        existing.setDestinationName("Paris");
+
+        Activity activity = new Activity();
+        activity.setId(100L);
+
+        Mockito.when(destinationRepository.findByIdAndTripId(11L, 1L)).thenReturn(Optional.of(existing));
+        Mockito.when(activityRepository.findByTripIdAndDestinationIdOrderByIdDesc(1L, 11L))
+                .thenReturn(List.of(activity));
+
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> destinationService.deleteDestination(1L, 11L, 1L));
+
+        assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
+        Mockito.verify(destinationRepository, Mockito.never()).delete(Mockito.any());
     }
 }


### PR DESCRIPTION
-only allow deleting destinations created by the current user
-block deletion when the destination still has associated activities
-validate the requester in the controller and publish updated trip data via SSE
-extend and adjust service/controller tests for success, forbidden, and conflict cases
close #185 close #186 close #187 close #188 close #189 close #195 close #196
