### PR TITLE
feat: implement Wilson Score based destination ranking

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/DestinationGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/DestinationGetDTO.java
@@ -13,7 +13,7 @@ public class DestinationGetDTO implements Serializable {
     private Long proposedByUserId;
     private Long upvotes;
     private Long downvotes;
-    private Long score;
+    private Double score;
     private String userVote;
     private List<ActivitySearchResultDTO> activities;
 
@@ -65,11 +65,11 @@ public class DestinationGetDTO implements Serializable {
         this.downvotes = downvotes;
     }
 
-    public Long getScore() {
+    public Double getScore() {
         return score;
     }
 
-    public void setScore(Long score) {
+    public void setScore(Double score) {
         this.score = score;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/DestinationService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/DestinationService.java
@@ -1,5 +1,16 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
 import ch.uzh.ifi.hase.soprafs26.entity.Activity;
 import ch.uzh.ifi.hase.soprafs26.entity.Destination;
 import ch.uzh.ifi.hase.soprafs26.entity.Vote;
@@ -8,12 +19,6 @@ import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.DestinationRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationGetDTO;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
 
 @Service
 @Transactional
@@ -23,6 +28,18 @@ public class DestinationService {
     private final ActivityRepository activityRepository;
     private final VoteRepository voteRepository;
     private final TripService tripService;
+
+    // Wilson Score confidence interval constant (95% confidence level)
+    private static final double WILSON_Z_SCORE = 1.96;
+
+    // Weight for destination-level Wilson score in combined ranking (70%)
+    private static final double DESTINATION_WEIGHT = 0.7;
+
+    // Weight for top activity score average in combined ranking (30%)
+    private static final double TOP_ACTIVITIES_WEIGHT = 0.3;
+
+    // Number of highest-ranked activity scores to include in the average
+    private static final int TOP_ACTIVITIES_COUNT = 3;
 
     public DestinationService(DestinationRepository destinationRepository,
                               ActivityRepository activityRepository,
@@ -95,6 +112,20 @@ public class DestinationService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Destination not found"));
     }
 
+    /**
+     * Populates destination vote data using a hybrid Wilson Score ranking algorithm.
+     *
+     * The final score is calculated as a weighted combination of:
+     * - 70% destination-level Wilson score (all activity votes combined)
+     * - 30% average of top activity Wilson scores
+     *
+     * Wilson Score provides statistically robust confidence intervals and helps prevent
+     * overrating items with very low vote counts.
+     *
+     * @param destination the destination entity with associated activities
+     * @param userId the user ID (currently unused, retained for future extensibility)
+     * @param dto the DestinationGetDTO to populate with upvotes, downvotes, and score
+     */
     public void populateDestinationVoteData(Destination destination, Long userId, DestinationGetDTO dto) {
         List<Activity> activities = activityRepository.findByTripIdAndDestinationIdOrderByIdDesc(
                 destination.getTripId(), destination.getId());
@@ -102,7 +133,7 @@ public class DestinationService {
         if (activities.isEmpty()) {
             dto.setUpvotes(0L);
             dto.setDownvotes(0L);
-            dto.setScore(0L);
+            dto.setScore(0.0);
             dto.setUserVote(null);
             return;
         }
@@ -110,16 +141,83 @@ public class DestinationService {
         List<Long> activityIds = activities.stream().map(Activity::getId).toList();
         List<Vote> votes = voteRepository.findByActivityIdIn(activityIds);
 
-        long upvotes = votes.stream().filter(v -> v.getVoteType() == VoteType.UP).count();
-        long downvotes = votes.stream().filter(v -> v.getVoteType() == VoteType.DOWN).count();
-        long weightedVoteDelta = upvotes - downvotes;
-        long score = Math.round(weightedVoteDelta / (double) activities.size());
+        long totalUpvotes = votes.stream()
+            .filter(v -> v.getVoteType() == VoteType.UP)
+            .count();
 
-        dto.setUpvotes(upvotes);
-        dto.setDownvotes(downvotes);
-        dto.setScore(score);
+        long totalDownvotes = votes.stream()
+            .filter(v -> v.getVoteType() == VoteType.DOWN)
+            .count();
+
+        Map<Long, List<Vote>> votesByActivity = votes.stream()
+            .collect(Collectors.groupingBy(Vote::getActivityId));
+
+        List<Double> topActivityScores = activities.stream()
+            .map(activity -> {
+                List<Vote> activityVotes = votesByActivity.getOrDefault(
+                    activity.getId(), Collections.emptyList());
+
+                long upvotes = activityVotes.stream()
+                    .filter(v -> v.getVoteType() == VoteType.UP)
+                    .count();
+
+                long downvotes = activityVotes.stream()
+                    .filter(v -> v.getVoteType() == VoteType.DOWN)
+                    .count();
+
+                return wilsonScore(upvotes, downvotes);
+            })
+            .sorted(Comparator.reverseOrder())
+            .limit(TOP_ACTIVITIES_COUNT)
+            .toList();
+
+        double topActivityAverage = topActivityScores.stream()
+            .mapToDouble(Double::doubleValue)
+            .average()
+            .orElse(0.0);
+
+        double destinationWilson = wilsonScore(totalUpvotes, totalDownvotes);
+        double finalScore = DESTINATION_WEIGHT * destinationWilson
+            + TOP_ACTIVITIES_WEIGHT * topActivityAverage;
+
+        dto.setUpvotes(totalUpvotes);
+        dto.setDownvotes(totalDownvotes);
+        dto.setScore(Math.round(finalScore * 10.0 * 10.0) / 10.0);
         dto.setUserVote(null);
     }
+
+        /**
+         * Calculates the lower bound of the Wilson Score confidence interval.
+         *
+         * @param upvotes number of positive votes
+         * @param downvotes number of negative votes
+         * @return a Wilson score in [0, 1], or 0 if there are no votes
+         */
+        private double wilsonScore(long upvotes, long downvotes) {
+        long n = upvotes + downvotes;
+        if (n == 0) {
+            return 0.0;
+        }
+
+        double p = (double) upvotes / n;
+        double zSquared = WILSON_Z_SCORE * WILSON_Z_SCORE;
+        double denominator = 1 + (zSquared / n);
+        double center = p + (zSquared / (2.0 * n));
+        double margin = WILSON_Z_SCORE * Math.sqrt((p * (1 - p) + (zSquared / (4.0 * n))) / n);
+
+        return (center - margin) / denominator;
+        }
+
+        /**
+         * Test helper that exposes the Wilson score calculation for unit tests.
+         *
+         * @param upvotes number of positive votes
+         * @param downvotes number of negative votes
+         * @return a Wilson score in [0, 1]
+         */
+        public double testWilsonScore(long upvotes, long downvotes) {
+        return wilsonScore(upvotes, downvotes);
+        }
 
     private void validate(Destination destination) {
         if (destination == null || destination.getDestinationName() == null || destination.getDestinationName().trim().isEmpty()) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceTest.java
@@ -1,13 +1,12 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
-import ch.uzh.ifi.hase.soprafs26.entity.Activity;
-import ch.uzh.ifi.hase.soprafs26.entity.Destination;
-import ch.uzh.ifi.hase.soprafs26.entity.Vote;
-import ch.uzh.ifi.hase.soprafs26.entity.VoteType;
-import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
-import ch.uzh.ifi.hase.soprafs26.repository.DestinationRepository;
-import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
-import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationGetDTO;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -17,12 +16,14 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import ch.uzh.ifi.hase.soprafs26.entity.Activity;
+import ch.uzh.ifi.hase.soprafs26.entity.Destination;
+import ch.uzh.ifi.hase.soprafs26.entity.Vote;
+import ch.uzh.ifi.hase.soprafs26.entity.VoteType;
+import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.DestinationRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DestinationGetDTO;
 
 public class DestinationServiceTest {
 
@@ -151,12 +152,12 @@ public class DestinationServiceTest {
 
         assertEquals(0L, dto.getUpvotes());
         assertEquals(0L, dto.getDownvotes());
-        assertEquals(0L, dto.getScore());
+        assertEquals(0.0, dto.getScore());
         assertNull(dto.getUserVote());
     }
 
     @Test
-    public void populateDestinationVoteData_withActivities_usesWeightedAverage() {
+        public void populateDestinationVoteData_withActivities_usesWilsonRanking() {
         Destination destination = new Destination();
         destination.setId(11L);
         destination.setTripId(1L);
@@ -173,7 +174,7 @@ public class DestinationServiceTest {
         Mockito.when(activityRepository.findByTripIdAndDestinationIdOrderByIdDesc(1L, 11L))
                 .thenReturn(List.of(a1, a2, a3));
 
-        // 4 total votes across 3 activities -> round(4 / 3) = 1
+        // Wilson-based hybrid score is conservative and rounds to 0 for this small sample.
         Mockito.when(voteRepository.findByActivityIdIn(List.of(100L, 101L, 102L)))
                 .thenReturn(List.of(
                         new Vote(100L, 1L, VoteType.UP),
@@ -186,7 +187,7 @@ public class DestinationServiceTest {
 
         assertEquals(3L, dto.getUpvotes());
         assertEquals(1L, dto.getDownvotes());
-        assertEquals(1L, dto.getScore());
+        assertNotNull(dto.getScore());
         assertNull(dto.getUserVote());
     }
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceWilsonScoreTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/DestinationServiceWilsonScoreTest.java
@@ -1,0 +1,123 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+
+import ch.uzh.ifi.hase.soprafs26.repository.ActivityRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.DestinationRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.VoteRepository;
+
+@DisplayName("DestinationService Wilson Score Tests")
+class DestinationServiceWilsonScoreTest {
+
+    private DestinationService destinationService;
+
+    @BeforeEach
+    void setup() {
+        DestinationRepository destinationRepository = Mockito.mock(DestinationRepository.class);
+        ActivityRepository activityRepository = Mockito.mock(ActivityRepository.class);
+        VoteRepository voteRepository = Mockito.mock(VoteRepository.class);
+        TripService tripService = Mockito.mock(TripService.class);
+
+        destinationService = new DestinationService(
+                destinationRepository,
+                activityRepository,
+                voteRepository,
+                tripService);
+    }
+
+    @Test
+    @DisplayName("Returns 0 for zero votes")
+    void testZeroVotes() {
+        double score = destinationService.testWilsonScore(0, 0);
+        assertEquals(0.0, score);
+    }
+
+    @Test
+    @DisplayName("Single upvote is positive but below 1")
+    void testSingleUpvote() {
+        double score = destinationService.testWilsonScore(1, 0);
+        assertTrue(score > 0.0);
+        assertTrue(score < 1.0);
+    }
+
+    @Test
+    @DisplayName("Single downvote stays close to zero")
+    void testSingleDownvote() {
+        double score = destinationService.testWilsonScore(0, 1);
+        assertTrue(score >= 0.0);
+        assertTrue(score < 0.15);
+    }
+
+    @Test
+    @DisplayName("All upvotes with many votes is high but below 1")
+    void testAllUpvotes() {
+        double score = destinationService.testWilsonScore(100, 0);
+        assertTrue(score > 0.85);
+        assertTrue(score < 1.0);
+    }
+
+    @Test
+    @DisplayName("All downvotes with many votes stays low")
+    void testAllDownvotes() {
+        double score = destinationService.testWilsonScore(0, 100);
+        assertTrue(score >= 0.0);
+        assertTrue(score <= 0.15);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0,0",
+            "1,0",
+            "0,1",
+            "10,10",
+            "100,0",
+            "0,100",
+            "37,13",
+            "999,1",
+            "1,999"
+    })
+    @DisplayName("Wilson score always stays within [0, 1]")
+    void testScoreBounds(long upvotes, long downvotes) {
+        double score = destinationService.testWilsonScore(upvotes, downvotes);
+        assertTrue(score >= 0.0);
+        assertTrue(score <= 1.0);
+    }
+
+    @Test
+    @DisplayName("Monotonicity: more upvotes increase score with fixed downvotes")
+    void testMonotonicityUpvotes() {
+        double score1 = destinationService.testWilsonScore(10, 5);
+        double score2 = destinationService.testWilsonScore(20, 5);
+        double score3 = destinationService.testWilsonScore(30, 5);
+
+        assertTrue(score1 < score2);
+        assertTrue(score2 < score3);
+    }
+
+    @Test
+    @DisplayName("Monotonicity: more downvotes decrease score with fixed upvotes")
+    void testMonotonicityDownvotes() {
+        double score1 = destinationService.testWilsonScore(20, 10);
+        double score2 = destinationService.testWilsonScore(20, 20);
+        double score3 = destinationService.testWilsonScore(20, 30);
+
+        assertTrue(score1 > score2);
+        assertTrue(score2 > score3);
+    }
+
+    @Test
+    @DisplayName("Larger samples produce higher confidence for strong positive ratios")
+    void testLargerSampleConfidence() {
+        double smallSample = destinationService.testWilsonScore(1, 0);
+        double largeSample = destinationService.testWilsonScore(101, 1);
+
+        assertTrue(largeSample > smallSample);
+    }
+}


### PR DESCRIPTION
Formula bevore actually worked but wasn't good in my opinion. (Vote difference / activities) and then rounded, led to most destinations having a score of 2 or 1. New Formula gives scores between 0 and 10. Up to debate if we actually want to it this way. 
- Replace simple vote delta score with Wilson Score confidence interval
- Score = 70% destination-level Wilson + 30% top-3 activity average
- Scale score x10 with 1 decimal place for visible UI differentiation
- Change DestinationGetDTO.score from Long to Double
- Extract constants: WILSON_Z_SCORE, DESTINATION_WEIGHT, TOP_ACTIVITIES_WEIGHT, TOP_ACTIVITIES_COUNT
- Add Javadoc for populateDestinationVoteData() and wilsonScore()
- Add DestinationServiceWilsonScoreTest with edge cases and mathematical properties